### PR TITLE
add keyboard layout for environmental station alpha

### DIFF
--- a/keyboards/GamesLegacy/game_esa/keyboard.json
+++ b/keyboards/GamesLegacy/game_esa/keyboard.json
@@ -1,0 +1,391 @@
+{
+  "Elements": [
+    {
+      "__type": "KeyboardKey",
+      "Id": 0,
+      "Boundaries": [
+        {
+          "X": 31,
+          "Y": 156
+        },
+        {
+          "X": 74,
+          "Y": 156
+        },
+        {
+          "X": 74,
+          "Y": 199
+        },
+        {
+          "X": 31,
+          "Y": 199
+        }
+      ],
+      "KeyCodes": [
+        37
+      ],
+      "Text": "←",
+      "TextPosition": {
+        "X": 52,
+        "Y": 177
+      },
+      "ChangeOnCaps": false,
+      "ShiftText": "←"
+    },
+    {
+      "__type": "KeyboardKey",
+      "Id": 1,
+      "Boundaries": [
+        {
+          "X": 75,
+          "Y": 112
+        },
+        {
+          "X": 118,
+          "Y": 112
+        },
+        {
+          "X": 118,
+          "Y": 155
+        },
+        {
+          "X": 75,
+          "Y": 155
+        }
+      ],
+      "KeyCodes": [
+        38
+      ],
+      "Text": "↑",
+      "TextPosition": {
+        "X": 96,
+        "Y": 133
+      },
+      "ChangeOnCaps": false,
+      "ShiftText": "↑"
+    },
+    {
+      "__type": "KeyboardKey",
+      "Id": 2,
+      "Boundaries": [
+        {
+          "X": 119,
+          "Y": 156
+        },
+        {
+          "X": 162,
+          "Y": 156
+        },
+        {
+          "X": 162,
+          "Y": 199
+        },
+        {
+          "X": 119,
+          "Y": 199
+        }
+      ],
+      "KeyCodes": [
+        39
+      ],
+      "Text": "→",
+      "TextPosition": {
+        "X": 140,
+        "Y": 177
+      },
+      "ChangeOnCaps": false,
+      "ShiftText": "→"
+    },
+    {
+      "__type": "KeyboardKey",
+      "Id": 3,
+      "Boundaries": [
+        {
+          "X": 75,
+          "Y": 156
+        },
+        {
+          "X": 118,
+          "Y": 156
+        },
+        {
+          "X": 118,
+          "Y": 199
+        },
+        {
+          "X": 75,
+          "Y": 199
+        }
+      ],
+      "KeyCodes": [
+        40
+      ],
+      "Text": "↓",
+      "TextPosition": {
+        "X": 96,
+        "Y": 177
+      },
+      "ChangeOnCaps": false,
+      "ShiftText": "↓"
+    },
+    {
+      "__type": "KeyboardKey",
+      "Id": 4,
+      "Boundaries": [
+        {
+          "X": 9,
+          "Y": 3
+        },
+        {
+          "X": 52,
+          "Y": 3
+        },
+        {
+          "X": 52,
+          "Y": 46
+        },
+        {
+          "X": 9,
+          "Y": 46
+        }
+      ],
+      "KeyCodes": [
+        65
+      ],
+      "Text": "A",
+      "TextPosition": {
+        "X": 30,
+        "Y": 24
+      },
+      "ChangeOnCaps": true,
+      "ShiftText": "A"
+    },
+    {
+      "__type": "KeyboardKey",
+      "Id": 6,
+      "Boundaries": [
+        {
+          "X": 53,
+          "Y": 3
+        },
+        {
+          "X": 96,
+          "Y": 3
+        },
+        {
+          "X": 96,
+          "Y": 46
+        },
+        {
+          "X": 53,
+          "Y": 46
+        }
+      ],
+      "KeyCodes": [
+        83
+      ],
+      "Text": "S",
+      "TextPosition": {
+        "X": 74,
+        "Y": 24
+      },
+      "ChangeOnCaps": true,
+      "ShiftText": "S"
+    },
+    {
+      "__type": "KeyboardKey",
+      "Id": 5,
+      "Boundaries": [
+        {
+          "X": 97,
+          "Y": 3
+        },
+        {
+          "X": 140,
+          "Y": 3
+        },
+        {
+          "X": 140,
+          "Y": 46
+        },
+        {
+          "X": 97,
+          "Y": 46
+        }
+      ],
+      "KeyCodes": [
+        68
+      ],
+      "Text": "D",
+      "TextPosition": {
+        "X": 118,
+        "Y": 24
+      },
+      "ChangeOnCaps": true,
+      "ShiftText": "D"
+    },
+    {
+      "__type": "KeyboardKey",
+      "Id": 5,
+      "Boundaries": [
+        {
+          "X": 141,
+          "Y": 3
+        },
+        {
+          "X": 184,
+          "Y": 3
+        },
+        {
+          "X": 184,
+          "Y": 46
+        },
+        {
+          "X": 141,
+          "Y": 46
+        }
+      ],
+      "KeyCodes": [
+        70
+      ],
+      "Text": "F",
+      "TextPosition": {
+        "X": 162,
+        "Y": 24
+      },
+      "ChangeOnCaps": true,
+      "ShiftText": "F"
+    },
+    {
+      "__type": "KeyboardKey",
+      "Id": 4,
+      "Boundaries": [
+        {
+          "X": 9,
+          "Y": 49
+        },
+        {
+          "X": 52,
+          "Y": 49
+        },
+        {
+          "X": 52,
+          "Y": 92
+        },
+        {
+          "X": 9,
+          "Y": 92
+        }
+      ],
+      "KeyCodes": [
+        90
+      ],
+      "Text": "Z",
+      "TextPosition": {
+        "X": 30,
+        "Y": 70
+      },
+      "ChangeOnCaps": true,
+      "ShiftText": "Z"
+    },
+    {
+      "__type": "KeyboardKey",
+      "Id": 6,
+      "Boundaries": [
+        {
+          "X": 53,
+          "Y": 49
+        },
+        {
+          "X": 96,
+          "Y": 49
+        },
+        {
+          "X": 96,
+          "Y": 92
+        },
+        {
+          "X": 53,
+          "Y": 92
+        }
+      ],
+      "KeyCodes": [
+        88
+      ],
+      "Text": "X",
+      "TextPosition": {
+        "X": 74,
+        "Y": 70
+      },
+      "ChangeOnCaps": true,
+      "ShiftText": "X"
+    },
+    {
+      "__type": "KeyboardKey",
+      "Id": 5,
+      "Boundaries": [
+        {
+          "X": 97,
+          "Y": 49
+        },
+        {
+          "X": 140,
+          "Y": 49
+        },
+        {
+          "X": 140,
+          "Y": 92
+        },
+        {
+          "X": 97,
+          "Y": 92
+        }
+      ],
+      "KeyCodes": [
+        67
+      ],
+      "Text": "C",
+      "TextPosition": {
+        "X": 118,
+        "Y": 70
+      },
+      "ChangeOnCaps": true,
+      "ShiftText": "C"
+    },
+    {
+      "__type": "KeyboardKey",
+      "Id": 5,
+      "Boundaries": [
+        {
+          "X": 141,
+          "Y": 49
+        },
+        {
+          "X": 184,
+          "Y": 49
+        },
+        {
+          "X": 184,
+          "Y": 92
+        },
+        {
+          "X": 141,
+          "Y": 92
+        }
+      ],
+      "KeyCodes": [
+        86
+      ],
+      "Text": "V",
+      "TextPosition": {
+        "X": 162,
+        "Y": 70
+      },
+      "ChangeOnCaps": true,
+      "ShiftText": "V"
+    }
+  ],
+  "Height": 249,
+  "Version": 2,
+  "Width": 191
+}

--- a/keyboards/GamesLegacy/game_esa/keyboard.json
+++ b/keyboards/GamesLegacy/game_esa/keyboard.json
@@ -152,7 +152,7 @@
       "KeyCodes": [
         65
       ],
-      "Text": "A",
+      "Text": "a",
       "TextPosition": {
         "X": 30,
         "Y": 24
@@ -184,7 +184,7 @@
       "KeyCodes": [
         83
       ],
-      "Text": "S",
+      "Text": "s",
       "TextPosition": {
         "X": 74,
         "Y": 24
@@ -216,7 +216,7 @@
       "KeyCodes": [
         68
       ],
-      "Text": "D",
+      "Text": "d",
       "TextPosition": {
         "X": 118,
         "Y": 24
@@ -248,7 +248,7 @@
       "KeyCodes": [
         70
       ],
-      "Text": "F",
+      "Text": "f",
       "TextPosition": {
         "X": 162,
         "Y": 24
@@ -280,7 +280,7 @@
       "KeyCodes": [
         90
       ],
-      "Text": "Z",
+      "Text": "z",
       "TextPosition": {
         "X": 30,
         "Y": 70
@@ -312,7 +312,7 @@
       "KeyCodes": [
         88
       ],
-      "Text": "X",
+      "Text": "x",
       "TextPosition": {
         "X": 74,
         "Y": 70
@@ -344,7 +344,7 @@
       "KeyCodes": [
         67
       ],
-      "Text": "C",
+      "Text": "c",
       "TextPosition": {
         "X": 118,
         "Y": 70
@@ -376,7 +376,7 @@
       "KeyCodes": [
         86
       ],
-      "Text": "V",
+      "Text": "v",
       "TextPosition": {
         "X": 162,
         "Y": 70


### PR DESCRIPTION
This PR adds a layout that shows the following keys:

A S D F
Z X C V

Arrow keys

It's useful for a bunch of older indie games that use this layout, such as Environmental Station Alpha and Cave Story.