### PR TITLE
Fixed a bug when closing the program while it's minimized

### DIFF
--- a/NohBoard/Forms/MainForm.Designer.cs
+++ b/NohBoard/Forms/MainForm.Designer.cs
@@ -401,6 +401,7 @@ namespace ThoNohT.NohBoard.Forms
             this.MouseDown += new System.Windows.Forms.MouseEventHandler(this.MainForm_MouseDown);
             this.MouseMove += new System.Windows.Forms.MouseEventHandler(this.MainForm_MouseMove);
             this.MouseUp += new System.Windows.Forms.MouseEventHandler(this.MainForm_MouseUp);
+            this.Move += new System.EventHandler(this.MainForm_Move);
             this.MainMenu.ResumeLayout(false);
             this.ResumeLayout(false);
 

--- a/NohBoard/Forms/MainForm.cs
+++ b/NohBoard/Forms/MainForm.cs
@@ -347,15 +347,24 @@ namespace ThoNohT.NohBoard.Forms
         }
 
         /// <summary>
-        /// Handles the closing of the form. Hooks are disabled and the current position is stored before closing.
+        /// Handles the moving of the form. Stores the current position for future use.
+        /// </summary>
+        private void MainForm_Move(object sender, EventArgs e)
+        {
+            if (GlobalSettings.Settings != null && WindowState == FormWindowState.Normal)
+            {
+                GlobalSettings.Settings.X = Location.X;
+                GlobalSettings.Settings.Y = Location.Y;
+            }
+        }
+
+        /// <summary>
+        /// Handles the closing of the form. Hooks are disabled and the settings are saved before closing.
         /// </summary>
         private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
         {
             HookManager.DisableMouseHook();
             HookManager.DisableKeyboardHook();
-
-            GlobalSettings.Settings.X = this.Location.X;
-            GlobalSettings.Settings.Y = this.Location.Y;
 
             GlobalSettings.Save();
         }

--- a/NohBoard/Forms/MainForm.cs
+++ b/NohBoard/Forms/MainForm.cs
@@ -351,10 +351,10 @@ namespace ThoNohT.NohBoard.Forms
         /// </summary>
         private void MainForm_Move(object sender, EventArgs e)
         {
-            if (GlobalSettings.Settings != null && WindowState == FormWindowState.Normal)
+            if (GlobalSettings.Settings != null && this.WindowState == FormWindowState.Normal)
             {
-                GlobalSettings.Settings.X = Location.X;
-                GlobalSettings.Settings.Y = Location.Y;
+                GlobalSettings.Settings.X = this.Location.X;
+                GlobalSettings.Settings.Y = this.Location.Y;
             }
         }
 


### PR DESCRIPTION
## Summary
When merged, this PR fixes a bug related to storing the main window location in NohBoard.json.

## Bug description
Currently, when you minimize the main window and quit the program from the task bar or by other means, the program stores the value `-32000` for its X and Y coordinates in NohBoard.json. Once restarted, the window will be off-screen and can not be recovered without manually changing the file.

## How to reproduce
1. Minimize NohBoard
2. Right click its task bar icon and close the program from there

## Solution
I moved the logic that stores the current window position from the `Closing` event to a `Move` event. It checks whether the current window state is normal (not minimized).