### PR TITLE
Fixed a bug where you could not move boundaries down in a list

### DIFF
--- a/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.Designer.cs
+++ b/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.Designer.cs
@@ -77,6 +77,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.btnBoundaryDown.TabIndex = 8;
             this.btnBoundaryDown.Text = "Down";
             this.btnBoundaryDown.UseVisualStyleBackColor = true;
+            this.btnBoundaryDown.Click += new System.EventHandler(this.btnBoundaryDown_Click);
             // 
             // btnBoundaryUp
             // 


### PR DESCRIPTION
When merged, this bug fixes the issue described in #56.

The click event of the button was simply not connected to the `btnBoundaryDown_Click` method.