### PR TITLE
Fixed a bug that would cause a key definition to reset

### DIFF
--- a/NohBoard/Forms/MainForm.Editmode.cs
+++ b/NohBoard/Forms/MainForm.Editmode.cs
@@ -703,6 +703,10 @@ namespace ThoNohT.NohBoard.Forms
             {
                 this.elementUnderCursor = null;
                 this.currentlyManipulating = null;
+                if (def.Equals(this.selectedDefinition))
+                {
+                    this.selectedDefinition = def;
+                }
 
                 var index = GlobalSettings.CurrentDefinition.Elements.IndexOf(def);
                 GlobalSettings.CurrentDefinition = GlobalSettings.CurrentDefinition


### PR DESCRIPTION
When merged, this PR will fix the issue described in #55.

I solved the issue by checking whether the definition that has been edited in the "Element Properties" is the one that is currently selected. If they are the same, I overwrite the selected definition with the edited one to update it.