### PR TITLE
Prevent removing the last boundary

### DIFF
--- a/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.cs
+++ b/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.cs
@@ -121,6 +121,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
         private void btnRemoveBoundary_Click(object sender, EventArgs e)
         {
             if (this.lstBoundaries.SelectedItem == null) return;
+            if (this.lstBoundaries.Items.Count < 2) return;
 
             var index = this.lstBoundaries.SelectedIndex;
             this.lstBoundaries.Items.Remove(this.lstBoundaries.SelectedItem);


### PR DESCRIPTION
When merged, this PR fixes the bug described in #54.

Removing the last boundary of a key crashes the application. The button to remove a boundary is now disabled if there are not enough items left in the list.