### PR TITLE
Prevent keyboard style from returning to default when opening the "Load Keyboard" dialog

### DIFF
--- a/NohBoard/Forms/LoadKeyboardForm.cs
+++ b/NohBoard/Forms/LoadKeyboardForm.cs
@@ -158,7 +158,19 @@ namespace ThoNohT.NohBoard.Forms
                 this.PopulateKeyboards();
 
                 if (GlobalSettings.Settings.LoadedKeyboard != null)
+                {
+                    var loadedStyle = GlobalSettings.Settings.LoadedStyle;
                     this.DefinitionsList.SelectedItem = GlobalSettings.Settings.LoadedKeyboard;
+
+                    if (loadedStyle != null)
+                    {
+                        var styleIndex = this.FindStyleListIndex(loadedStyle);
+                        if (styleIndex != -1)
+                        {
+                            this.StyleList.SelectedIndex = styleIndex;
+                        }
+                    }
+                }
             }
             this.loaded = true;
         }
@@ -270,6 +282,23 @@ namespace ThoNohT.NohBoard.Forms
             this.StyleList.Items.Clear();
             this.StyleList.Items.AddRange(this.globalStyles.Cast<object>().ToArray());
             this.StyleList.Items.AddRange(specificStyles.Cast<object>().ToArray());
+        }
+
+        /// <summary>
+        /// Returns the index of an item in StyleList that has a given name.
+        /// </summary>
+        private int FindStyleListIndex(string styleName)
+        {
+            for (int i = 0; i < this.StyleList.Items.Count; i++)
+            {
+                var item = (StyleInfo)this.StyleList.Items[i];
+                if (item.Name == styleName)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
         }
 
         #endregion Helpers


### PR DESCRIPTION
When merged, this PR fixes the issue described in #25.

I created a helper method called `FindStyleListIndex` for `LoadKeyboardForm` that returns the index of a given style inside `StyleList`. That can be used to set the selection to whatever `GlobalSettings.Settings.LoadedStyle` is at the time of opening the form.

I'm not too sure about this one when it comes to code style. I tested it and it works, but I'm not very familiar with how you do things in C#, so this might be "ugly" code.