### PR TITLE
Add a dialog for easier rectangle boundary creation

### DIFF
--- a/NohBoard/Extra/TRectangle.cs
+++ b/NohBoard/Extra/TRectangle.cs
@@ -15,11 +15,11 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using System;
-using System.Drawing;
-
 namespace ThoNohT.NohBoard.Extra
 {
+    using System;
+    using System.Drawing;
+
     /// <summary>
     /// Represents a rectangle, defined by 4 integer values.
     /// </summary>

--- a/NohBoard/Extra/TRectangle.cs
+++ b/NohBoard/Extra/TRectangle.cs
@@ -1,27 +1,115 @@
-﻿using System;
-using System.Collections.Generic;
+﻿/*
+Copyright (C) 2016 by Marius Becker <marius.becker.8@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System;
 using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ThoNohT.NohBoard.Extra
 {
     /// <summary>
-    /// Represents a rectangle, defind by 4 integer values.
+    /// Represents a rectangle, defined by 4 integer values.
     /// </summary>
     public class TRectangle
     {
-        #region Properties
+        #region Constructors
 
+        /// <summary>
+        /// Creates a new <see cref="TRectangle" /> instance from its left, top, right and bottom edges.
+        /// </summary>
+        public TRectangle(int left, int top, int right, int bottom)
+        {
+            this.Left = left;
+            this.Top = top;
+            this.Right = right;
+            this.Bottom = bottom;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="TRectangle" /> instance from a position and size.
+        /// </summary>
+        public TRectangle(TPoint position, TPoint size)
+        {
+            this.Left = position.X;
+            this.Top = position.Y;
+            this.Right = position.X + size.X;
+            this.Bottom = position.Y + size.Y;
+        }
+
+        #endregion Constructors
+
+        #region Edges
+
+        /// <summary>
+        /// X-coordinate of the left edge
+        /// </summary>
         public int Left { get; private set; }
+
+        /// <summary>
+        /// Y-coordinate of the top edge
+        /// </summary>
         public int Top { get; private set; }
+
+        /// <summary>
+        /// X-coordinate of the rightedge
+        /// </summary>
         public int Right { get; private set; }
+
+        /// <summary>
+        /// Y-coordinate of the bottom edge
+        /// </summary>
         public int Bottom { get; private set; }
 
-        #endregion Properties
+        #endregion Edges
 
-        #region Constructors
+        #region Corner points
+
+        /// <summary>
+        /// Alias for TopLeft.
+        /// </summary>
+        public TPoint Position => this.TopLeft;
+
+        /// <summary>
+        /// Returns a Size object with the Width and Height properties of this rectangle.
+        /// </summary>
+        public Size Size =>new Size(this.Right - this.Left, this.Bottom - this.Top);
+
+        /// <summary>
+        /// Returns the top left corner of the rectangle as a TPoint.
+        /// </summary>
+        public TPoint TopLeft => new TPoint(this.Left, this.Top);
+
+        /// <summary>
+        /// Returns the top right corner of the rectangle as a TPoint.
+        /// </summary>
+        public TPoint TopRight => new TPoint(this.Right, this.Top);
+
+        /// <summary>
+        /// Returns the bottom left corner of the rectangle as a TPoint.
+        /// </summary>
+        public TPoint BottomLeft => new TPoint(this.Left, this.Bottom);
+
+        /// <summary>
+        /// Returns the bottom right corner of the rectangle as a TPoint.
+        /// </summary>
+        public TPoint BottomRight => new TPoint(this.Right, this.Bottom);
+
+        #endregion Corner points
+
+        #region Methods
 
         /// <summary>
         /// Creates a rectangle that surrounds all points in a list.
@@ -44,92 +132,6 @@ namespace ThoNohT.NohBoard.Extra
             return new TRectangle(left, top, right, bottom);
         }
 
-        public TRectangle(int left, int top, int right, int bottom)
-        {
-            this.Left = left;
-            this.Top = top;
-            this.Right = right;
-            this.Bottom = bottom;
-        }
-
-        public TRectangle(TPoint position, TPoint size)
-        {
-            this.Left = position.X;
-            this.Top = position.Y;
-            this.Right = position.X + size.X;
-            this.Bottom = position.Y + size.Y;
-        }
-
-        #endregion Constructors
-
-        #region Corner points
-
-        /// <summary>
-        /// Alias for TopLeft.
-        /// </summary>
-        public TPoint Position
-        {
-            get
-            {
-                return this.TopLeft;
-            }
-        }
-
-        /// <summary>
-        /// Returns a TPoint where X is the width and Y is the height of the rectangle.
-        /// </summary>
-        public Size Size
-        {
-            get
-            {
-                return new Size(this.Right - this.Left, this.Bottom - this.Top);
-            }
-        }
-
-        /// <summary>
-        /// Returns the top left corner of the rectangle as a TPoint.
-        /// </summary>
-        public TPoint TopLeft
-        {
-            get
-            {
-                return new TPoint(this.Left, this.Top);
-            }
-        }
-
-        /// <summary>
-        /// Returns the top left corner of the rectangle as a TPoint.
-        /// </summary>
-        public TPoint TopRight
-        {
-            get
-            {
-                return new TPoint(this.Right, this.Top);
-            }
-        }
-
-        /// <summary>
-        /// Returns the bottom left corner of the rectangle as a TPoint.
-        /// </summary>
-        public TPoint BottomLeft
-        {
-            get
-            {
-                return new TPoint(this.Left, this.Bottom);
-            }
-        }
-
-        /// <summary>
-        /// Returns the bottom right corner of the rectangle as a TPoint.
-        /// </summary>
-        public TPoint BottomRight
-        {
-            get
-            {
-                return new TPoint(this.Right, this.Bottom);
-            }
-        }
-
-        #endregion Corner points
+        #endregion
     }
 }

--- a/NohBoard/Extra/TRectangle.cs
+++ b/NohBoard/Extra/TRectangle.cs
@@ -132,6 +132,6 @@ namespace ThoNohT.NohBoard.Extra
             return new TRectangle(left, top, right, bottom);
         }
 
-        #endregion
+        #endregion Methods
     }
 }

--- a/NohBoard/Extra/TRectangle.cs
+++ b/NohBoard/Extra/TRectangle.cs
@@ -85,7 +85,7 @@ namespace ThoNohT.NohBoard.Extra
         /// <summary>
         /// Returns a Size object with the Width and Height properties of this rectangle.
         /// </summary>
-        public Size Size =>new Size(this.Right - this.Left, this.Bottom - this.Top);
+        public Size Size => new Size(this.Right - this.Left, this.Bottom - this.Top);
 
         /// <summary>
         /// Returns the top left corner of the rectangle as a TPoint.

--- a/NohBoard/Extra/TRectangle.cs
+++ b/NohBoard/Extra/TRectangle.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ThoNohT.NohBoard.Extra
+{
+    /// <summary>
+    /// Represents a rectangle, defind by 4 integer values.
+    /// </summary>
+    public class TRectangle
+    {
+        #region Properties
+
+        public int Left { get; private set; }
+        public int Top { get; private set; }
+        public int Right { get; private set; }
+        public int Bottom { get; private set; }
+
+        #endregion Properties
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a rectangle that surrounds all points in a list.
+        /// </summary>
+        public static TRectangle FromPointList(TPoint[] points)
+        {
+            var left = int.MaxValue;
+            var top = int.MaxValue;
+            var right = int.MinValue;
+            var bottom = int.MinValue;
+
+            foreach (var point in points)
+            {
+                left = Math.Min(left, point.X);
+                top = Math.Min(top, point.Y);
+                right = Math.Max(right, point.X);
+                bottom = Math.Max(bottom, point.Y);
+            }
+
+            return new TRectangle(left, top, right, bottom);
+        }
+
+        public TRectangle(int left, int top, int right, int bottom)
+        {
+            this.Left = left;
+            this.Top = top;
+            this.Right = right;
+            this.Bottom = bottom;
+        }
+
+        public TRectangle(TPoint position, TPoint size)
+        {
+            this.Left = position.X;
+            this.Top = position.Y;
+            this.Right = position.X + size.X;
+            this.Bottom = position.Y + size.Y;
+        }
+
+        #endregion Constructors
+
+        #region Corner points
+
+        /// <summary>
+        /// Alias for TopLeft.
+        /// </summary>
+        public TPoint Position
+        {
+            get
+            {
+                return this.TopLeft;
+            }
+        }
+
+        /// <summary>
+        /// Returns a TPoint where X is the width and Y is the height of the rectangle.
+        /// </summary>
+        public Size Size
+        {
+            get
+            {
+                return new Size(this.Right - this.Left, this.Bottom - this.Top);
+            }
+        }
+
+        /// <summary>
+        /// Returns the top left corner of the rectangle as a TPoint.
+        /// </summary>
+        public TPoint TopLeft
+        {
+            get
+            {
+                return new TPoint(this.Left, this.Top);
+            }
+        }
+
+        /// <summary>
+        /// Returns the top left corner of the rectangle as a TPoint.
+        /// </summary>
+        public TPoint TopRight
+        {
+            get
+            {
+                return new TPoint(this.Right, this.Top);
+            }
+        }
+
+        /// <summary>
+        /// Returns the bottom left corner of the rectangle as a TPoint.
+        /// </summary>
+        public TPoint BottomLeft
+        {
+            get
+            {
+                return new TPoint(this.Left, this.Bottom);
+            }
+        }
+
+        /// <summary>
+        /// Returns the bottom right corner of the rectangle as a TPoint.
+        /// </summary>
+        public TPoint BottomRight
+        {
+            get
+            {
+                return new TPoint(this.Right, this.Bottom);
+            }
+        }
+
+        #endregion Corner points
+    }
+}

--- a/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.Designer.cs
+++ b/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.Designer.cs
@@ -67,6 +67,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.lblKeyCodes = new System.Windows.Forms.Label();
             this.chkChangeOnCaps = new System.Windows.Forms.CheckBox();
             this.btnUpdateBoundary = new System.Windows.Forms.Button();
+            this.btnRectangle = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.udKeyCode)).BeginInit();
             this.SuspendLayout();
             // 
@@ -126,7 +127,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             // CancelButton2
             // 
             this.CancelButton2.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.CancelButton2.Location = new System.Drawing.Point(324, 232);
+            this.CancelButton2.Location = new System.Drawing.Point(328, 261);
             this.CancelButton2.Name = "CancelButton2";
             this.CancelButton2.Size = new System.Drawing.Size(75, 23);
             this.CancelButton2.TabIndex = 15;
@@ -136,7 +137,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             // 
             // AcceptButton2
             // 
-            this.AcceptButton2.Location = new System.Drawing.Point(405, 232);
+            this.AcceptButton2.Location = new System.Drawing.Point(405, 261);
             this.AcceptButton2.Name = "AcceptButton2";
             this.AcceptButton2.Size = new System.Drawing.Size(75, 23);
             this.AcceptButton2.TabIndex = 16;
@@ -158,7 +159,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.lstBoundaries.FormattingEnabled = true;
             this.lstBoundaries.Location = new System.Drawing.Point(85, 116);
             this.lstBoundaries.Name = "lstBoundaries";
-            this.lstBoundaries.Size = new System.Drawing.Size(156, 134);
+            this.lstBoundaries.Size = new System.Drawing.Size(156, 160);
             this.lstBoundaries.TabIndex = 10;
             // 
             // lblText
@@ -220,7 +221,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.lstKeyCodes.FormattingEnabled = true;
             this.lstKeyCodes.Location = new System.Drawing.Point(328, 64);
             this.lstKeyCodes.Name = "lstKeyCodes";
-            this.lstKeyCodes.Size = new System.Drawing.Size(151, 160);
+            this.lstKeyCodes.Size = new System.Drawing.Size(151, 186);
             this.lstKeyCodes.TabIndex = 14;
             // 
             // btnRemoveKeyCode
@@ -294,14 +295,25 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.btnUpdateBoundary.UseVisualStyleBackColor = true;
             this.btnUpdateBoundary.Click += new System.EventHandler(this.btnUpdateBoundary_Click);
             // 
+            // btnRectangle
+            // 
+            this.btnRectangle.Location = new System.Drawing.Point(4, 261);
+            this.btnRectangle.Name = "btnRectangle";
+            this.btnRectangle.Size = new System.Drawing.Size(75, 23);
+            this.btnRectangle.TabIndex = 53;
+            this.btnRectangle.Text = "Rectangle";
+            this.btnRectangle.UseVisualStyleBackColor = true;
+            this.btnRectangle.Click += new System.EventHandler(this.btnRectangle_Click);
+            // 
             // KeyboardKeyPropertiesForm
             // 
             this.AcceptButton = this.AcceptButton2;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.CancelButton2;
-            this.ClientSize = new System.Drawing.Size(492, 261);
+            this.ClientSize = new System.Drawing.Size(492, 293);
             this.Controls.Add(this.btnUpdateBoundary);
+            this.Controls.Add(this.btnRectangle);
             this.Controls.Add(this.chkChangeOnCaps);
             this.Controls.Add(this.lblKeyCodes);
             this.Controls.Add(this.udKeyCode);
@@ -358,5 +370,6 @@ namespace ThoNohT.NohBoard.Forms.Properties
         private System.Windows.Forms.Label lblKeyCodes;
         private System.Windows.Forms.CheckBox chkChangeOnCaps;
         private System.Windows.Forms.Button btnUpdateBoundary;
+        private System.Windows.Forms.Button btnRectangle;
     }
 }

--- a/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.Designer.cs
+++ b/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.Designer.cs
@@ -76,7 +76,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.btnBoundaryDown.Location = new System.Drawing.Point(4, 232);
             this.btnBoundaryDown.Name = "btnBoundaryDown";
             this.btnBoundaryDown.Size = new System.Drawing.Size(75, 23);
-            this.btnBoundaryDown.TabIndex = 9;
+            this.btnBoundaryDown.TabIndex = 8;
             this.btnBoundaryDown.Text = "Down";
             this.btnBoundaryDown.UseVisualStyleBackColor = true;
             this.btnBoundaryDown.Click += new System.EventHandler(this.btnBoundaryDown_Click);
@@ -86,7 +86,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.btnBoundaryUp.Location = new System.Drawing.Point(4, 203);
             this.btnBoundaryUp.Name = "btnBoundaryUp";
             this.btnBoundaryUp.Size = new System.Drawing.Size(75, 23);
-            this.btnBoundaryUp.TabIndex = 8;
+            this.btnBoundaryUp.TabIndex = 7;
             this.btnBoundaryUp.Text = "Up";
             this.btnBoundaryUp.UseVisualStyleBackColor = true;
             this.btnBoundaryUp.Click += new System.EventHandler(this.btnBoundaryUp_Click);
@@ -96,7 +96,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.btnRemoveBoundary.Location = new System.Drawing.Point(4, 174);
             this.btnRemoveBoundary.Name = "btnRemoveBoundary";
             this.btnRemoveBoundary.Size = new System.Drawing.Size(75, 23);
-            this.btnRemoveBoundary.TabIndex = 7;
+            this.btnRemoveBoundary.TabIndex = 6;
             this.btnRemoveBoundary.Text = "Remove";
             this.btnRemoveBoundary.UseVisualStyleBackColor = true;
             this.btnRemoveBoundary.Click += new System.EventHandler(this.btnRemoveBoundary_Click);
@@ -106,7 +106,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.btnAddBoundary.Location = new System.Drawing.Point(4, 116);
             this.btnAddBoundary.Name = "btnAddBoundary";
             this.btnAddBoundary.Size = new System.Drawing.Size(75, 23);
-            this.btnAddBoundary.TabIndex = 5;
+            this.btnAddBoundary.TabIndex = 4;
             this.btnAddBoundary.Text = "Add";
             this.btnAddBoundary.UseVisualStyleBackColor = true;
             this.btnAddBoundary.Click += new System.EventHandler(this.btnAddBoundary_Click);
@@ -119,7 +119,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.txtBoundaries.Separator = ';';
             this.txtBoundaries.Size = new System.Drawing.Size(156, 20);
             this.txtBoundaries.SpacesAroundSeparator = true;
-            this.txtBoundaries.TabIndex = 4;
+            this.txtBoundaries.TabIndex = 3;
             this.txtBoundaries.Text = "0 ; 0";
             this.txtBoundaries.X = 0;
             this.txtBoundaries.Y = 0;
@@ -176,7 +176,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.txtText.Location = new System.Drawing.Point(85, 11);
             this.txtText.Name = "txtText";
             this.txtText.Size = new System.Drawing.Size(156, 20);
-            this.txtText.TabIndex = 1;
+            this.txtText.TabIndex = 0;
             // 
             // txtTextPosition
             // 
@@ -186,7 +186,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.txtTextPosition.Separator = ';';
             this.txtTextPosition.Size = new System.Drawing.Size(156, 20);
             this.txtTextPosition.SpacesAroundSeparator = true;
-            this.txtTextPosition.TabIndex = 3;
+            this.txtTextPosition.TabIndex = 2;
             this.txtTextPosition.Text = "0 ; 0";
             this.txtTextPosition.X = 0;
             this.txtTextPosition.Y = 0;
@@ -214,7 +214,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.txtShiftText.Location = new System.Drawing.Point(85, 37);
             this.txtShiftText.Name = "txtShiftText";
             this.txtShiftText.Size = new System.Drawing.Size(156, 20);
-            this.txtShiftText.TabIndex = 2;
+            this.txtShiftText.TabIndex = 1;
             // 
             // lstKeyCodes
             // 
@@ -290,7 +290,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.btnUpdateBoundary.Location = new System.Drawing.Point(4, 145);
             this.btnUpdateBoundary.Name = "btnUpdateBoundary";
             this.btnUpdateBoundary.Size = new System.Drawing.Size(75, 23);
-            this.btnUpdateBoundary.TabIndex = 6;
+            this.btnUpdateBoundary.TabIndex = 5;
             this.btnUpdateBoundary.Text = "Update";
             this.btnUpdateBoundary.UseVisualStyleBackColor = true;
             this.btnUpdateBoundary.Click += new System.EventHandler(this.btnUpdateBoundary_Click);
@@ -300,7 +300,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.btnRectangle.Location = new System.Drawing.Point(4, 261);
             this.btnRectangle.Name = "btnRectangle";
             this.btnRectangle.Size = new System.Drawing.Size(75, 23);
-            this.btnRectangle.TabIndex = 53;
+            this.btnRectangle.TabIndex = 9;
             this.btnRectangle.Text = "Rectangle";
             this.btnRectangle.UseVisualStyleBackColor = true;
             this.btnRectangle.Click += new System.EventHandler(this.btnRectangle_Click);

--- a/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.cs
+++ b/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.cs
@@ -191,6 +191,36 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.DefinitionChanged?.Invoke(this.currentDefinition);
         }
 
+        /// <summary>
+        /// Handles the click even of the "Rectangle" button, opens the dialog.
+        /// </summary>
+        private void btnRectangle_Click(object sender, EventArgs e)
+        {
+            var rectangle = TRectangle.FromPointList(this.lstBoundaries.Items.Cast<TPoint>().ToArray());
+            using (var rectangleForm = new RectangleBoundaryForm(rectangle))
+            {
+                rectangleForm.DimensionsSet += OnRectangleDimensionsSet;
+                rectangleForm.ShowDialog(this);
+                return;
+            }
+        }
+
+        /// <summary>
+        /// Called when the user clicks "Apply" in the rectangle dialog. Sets the new boundaries and invokes the changed event.
+        /// </summary>
+        private void OnRectangleDimensionsSet(TRectangle rectangle)
+        {
+            this.lstBoundaries.Items.Clear();
+            this.lstBoundaries.Items.Add(rectangle.TopLeft);
+            this.lstBoundaries.Items.Add(rectangle.TopRight);
+            this.lstBoundaries.Items.Add(rectangle.BottomRight);
+            this.lstBoundaries.Items.Add(rectangle.BottomLeft);
+
+            this.currentDefinition =
+                this.currentDefinition.Modify(boundaries: this.lstBoundaries.Items.Cast<TPoint>().ToList());
+            this.DefinitionChanged?.Invoke(this.currentDefinition);
+        }
+
         #endregion Boundaries
 
         #region KeyCodes

--- a/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.cs
+++ b/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.cs
@@ -201,7 +201,6 @@ namespace ThoNohT.NohBoard.Forms.Properties
             {
                 rectangleForm.DimensionsSet += OnRectangleDimensionsSet;
                 rectangleForm.ShowDialog(this);
-                return;
             }
         }
 

--- a/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.cs
+++ b/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.cs
@@ -192,7 +192,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
         }
 
         /// <summary>
-        /// Handles the click even of the "Rectangle" button, opens the dialog.
+        /// Handles the click event of the "Rectangle" button, opens the dialog.
         /// </summary>
         private void btnRectangle_Click(object sender, EventArgs e)
         {

--- a/NohBoard/Forms/Properties/MouseElementPropertiesForm.Designer.cs
+++ b/NohBoard/Forms/Properties/MouseElementPropertiesForm.Designer.cs
@@ -61,6 +61,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.btnBoundaryUp = new System.Windows.Forms.Button();
             this.btnBoundaryDown = new System.Windows.Forms.Button();
             this.btnUpdateBoundary = new System.Windows.Forms.Button();
+            this.btnRectangle = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // txtTextPosition
@@ -71,7 +72,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.txtTextPosition.Separator = ';';
             this.txtTextPosition.Size = new System.Drawing.Size(156, 20);
             this.txtTextPosition.SpacesAroundSeparator = true;
-            this.txtTextPosition.TabIndex = 3;
+            this.txtTextPosition.TabIndex = 2;
             this.txtTextPosition.Text = "0 ; 0";
             this.txtTextPosition.X = 0;
             this.txtTextPosition.Y = 0;
@@ -123,7 +124,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.lstBoundaries.FormattingEnabled = true;
             this.lstBoundaries.Location = new System.Drawing.Point(85, 117);
             this.lstBoundaries.Name = "lstBoundaries";
-            this.lstBoundaries.Size = new System.Drawing.Size(156, 108);
+            this.lstBoundaries.Size = new System.Drawing.Size(156, 134);
             this.lstBoundaries.TabIndex = 10;
             // 
             // lblBoundaries
@@ -138,7 +139,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             // CancelButton2
             // 
             this.CancelButton2.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.CancelButton2.Location = new System.Drawing.Point(85, 233);
+            this.CancelButton2.Location = new System.Drawing.Point(85, 262);
             this.CancelButton2.Name = "CancelButton2";
             this.CancelButton2.Size = new System.Drawing.Size(75, 23);
             this.CancelButton2.TabIndex = 11;
@@ -148,7 +149,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             // 
             // AcceptButton2
             // 
-            this.AcceptButton2.Location = new System.Drawing.Point(166, 233);
+            this.AcceptButton2.Location = new System.Drawing.Point(166, 262);
             this.AcceptButton2.Name = "AcceptButton2";
             this.AcceptButton2.Size = new System.Drawing.Size(75, 23);
             this.AcceptButton2.TabIndex = 12;
@@ -164,7 +165,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.txtBoundaries.Separator = ';';
             this.txtBoundaries.Size = new System.Drawing.Size(156, 20);
             this.txtBoundaries.SpacesAroundSeparator = true;
-            this.txtBoundaries.TabIndex = 4;
+            this.txtBoundaries.TabIndex = 3;
             this.txtBoundaries.Text = "0 ; 0";
             this.txtBoundaries.X = 0;
             this.txtBoundaries.Y = 0;
@@ -219,14 +220,25 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.btnUpdateBoundary.UseVisualStyleBackColor = true;
             this.btnUpdateBoundary.Click += new System.EventHandler(this.btnUpdateBoundary_Click);
             // 
+            // btnRectangle
+            // 
+            this.btnRectangle.Location = new System.Drawing.Point(4, 262);
+            this.btnRectangle.Name = "btnRectangle";
+            this.btnRectangle.Size = new System.Drawing.Size(75, 23);
+            this.btnRectangle.TabIndex = 8;
+            this.btnRectangle.Text = "Rectangle";
+            this.btnRectangle.UseVisualStyleBackColor = true;
+            this.btnRectangle.Click += new System.EventHandler(this.btnRectangle_Click);
+            // 
             // MouseElementPropertiesForm
             // 
             this.AcceptButton = this.AcceptButton2;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.CancelButton2;
-            this.ClientSize = new System.Drawing.Size(253, 261);
+            this.ClientSize = new System.Drawing.Size(253, 292);
             this.Controls.Add(this.btnUpdateBoundary);
+            this.Controls.Add(this.btnRectangle);
             this.Controls.Add(this.btnBoundaryDown);
             this.Controls.Add(this.btnBoundaryUp);
             this.Controls.Add(this.btnRemoveBoundary);
@@ -270,5 +282,6 @@ namespace ThoNohT.NohBoard.Forms.Properties
         private System.Windows.Forms.Button btnBoundaryUp;
         private System.Windows.Forms.Button btnBoundaryDown;
         private System.Windows.Forms.Button btnUpdateBoundary;
+        private System.Windows.Forms.Button btnRectangle;
     }
 }

--- a/NohBoard/Forms/Properties/MouseElementPropertiesForm.Designer.cs
+++ b/NohBoard/Forms/Properties/MouseElementPropertiesForm.Designer.cs
@@ -91,7 +91,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.txtText.Location = new System.Drawing.Point(85, 39);
             this.txtText.Name = "txtText";
             this.txtText.Size = new System.Drawing.Size(156, 20);
-            this.txtText.TabIndex = 2;
+            this.txtText.TabIndex = 1;
             // 
             // lblText
             // 
@@ -108,7 +108,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.cmbKeyCode.Location = new System.Drawing.Point(85, 12);
             this.cmbKeyCode.Name = "cmbKeyCode";
             this.cmbKeyCode.Size = new System.Drawing.Size(156, 21);
-            this.cmbKeyCode.TabIndex = 1;
+            this.cmbKeyCode.TabIndex = 0;
             // 
             // lblKeyCode
             // 
@@ -175,7 +175,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.btnAddBoundary.Location = new System.Drawing.Point(4, 117);
             this.btnAddBoundary.Name = "btnAddBoundary";
             this.btnAddBoundary.Size = new System.Drawing.Size(75, 23);
-            this.btnAddBoundary.TabIndex = 5;
+            this.btnAddBoundary.TabIndex = 4;
             this.btnAddBoundary.Text = "Add";
             this.btnAddBoundary.UseVisualStyleBackColor = true;
             this.btnAddBoundary.Click += new System.EventHandler(this.btnAddBoundary_Click);
@@ -185,7 +185,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.btnRemoveBoundary.Location = new System.Drawing.Point(4, 175);
             this.btnRemoveBoundary.Name = "btnRemoveBoundary";
             this.btnRemoveBoundary.Size = new System.Drawing.Size(75, 23);
-            this.btnRemoveBoundary.TabIndex = 7;
+            this.btnRemoveBoundary.TabIndex = 6;
             this.btnRemoveBoundary.Text = "Remove";
             this.btnRemoveBoundary.UseVisualStyleBackColor = true;
             this.btnRemoveBoundary.Click += new System.EventHandler(this.btnRemoveBoundary_Click);
@@ -195,7 +195,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.btnBoundaryUp.Location = new System.Drawing.Point(4, 204);
             this.btnBoundaryUp.Name = "btnBoundaryUp";
             this.btnBoundaryUp.Size = new System.Drawing.Size(75, 23);
-            this.btnBoundaryUp.TabIndex = 8;
+            this.btnBoundaryUp.TabIndex = 7;
             this.btnBoundaryUp.Text = "Up";
             this.btnBoundaryUp.UseVisualStyleBackColor = true;
             this.btnBoundaryUp.Click += new System.EventHandler(this.btnBoundaryUp_Click);
@@ -205,7 +205,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.btnBoundaryDown.Location = new System.Drawing.Point(4, 233);
             this.btnBoundaryDown.Name = "btnBoundaryDown";
             this.btnBoundaryDown.Size = new System.Drawing.Size(75, 23);
-            this.btnBoundaryDown.TabIndex = 9;
+            this.btnBoundaryDown.TabIndex = 8;
             this.btnBoundaryDown.Text = "Down";
             this.btnBoundaryDown.UseVisualStyleBackColor = true;
             this.btnBoundaryDown.Click += new System.EventHandler(this.btnBoundaryDown_Click);
@@ -215,7 +215,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.btnUpdateBoundary.Location = new System.Drawing.Point(4, 146);
             this.btnUpdateBoundary.Name = "btnUpdateBoundary";
             this.btnUpdateBoundary.Size = new System.Drawing.Size(75, 23);
-            this.btnUpdateBoundary.TabIndex = 6;
+            this.btnUpdateBoundary.TabIndex = 5;
             this.btnUpdateBoundary.Text = "Update";
             this.btnUpdateBoundary.UseVisualStyleBackColor = true;
             this.btnUpdateBoundary.Click += new System.EventHandler(this.btnUpdateBoundary_Click);
@@ -225,7 +225,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.btnRectangle.Location = new System.Drawing.Point(4, 262);
             this.btnRectangle.Name = "btnRectangle";
             this.btnRectangle.Size = new System.Drawing.Size(75, 23);
-            this.btnRectangle.TabIndex = 8;
+            this.btnRectangle.TabIndex = 9;
             this.btnRectangle.Text = "Rectangle";
             this.btnRectangle.UseVisualStyleBackColor = true;
             this.btnRectangle.Click += new System.EventHandler(this.btnRectangle_Click);

--- a/NohBoard/Forms/Properties/MouseElementPropertiesForm.cs
+++ b/NohBoard/Forms/Properties/MouseElementPropertiesForm.cs
@@ -269,5 +269,34 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.DefinitionChanged?.Invoke(this.initialDefinition);
             this.DialogResult = DialogResult.Cancel;
         }
+
+        /// <summary>
+        /// Handles the click event of the "Rectangle" button, opens the dialog.
+        /// </summary>
+        private void btnRectangle_Click(object sender, EventArgs e)
+        {
+            var rectangle = TRectangle.FromPointList(this.lstBoundaries.Items.Cast<TPoint>().ToArray());
+            using (var rectangleForm = new RectangleBoundaryForm(rectangle))
+            {
+                rectangleForm.DimensionsSet += OnRectangleDimensionsSet;
+                rectangleForm.ShowDialog(this);
+            }
+        }
+
+        /// <summary>
+        /// Called when the user clicks "Apply" in the rectangle dialog. Sets the new boundaries and invokes the changed event.
+        /// </summary>
+        private void OnRectangleDimensionsSet(TRectangle rectangle)
+        {
+            this.lstBoundaries.Items.Clear();
+            this.lstBoundaries.Items.Add(rectangle.TopLeft);
+            this.lstBoundaries.Items.Add(rectangle.TopRight);
+            this.lstBoundaries.Items.Add(rectangle.BottomRight);
+            this.lstBoundaries.Items.Add(rectangle.BottomLeft);
+
+            this.currentDefinition =
+                this.currentDefinition.ModifyMouse(boundaries: this.lstBoundaries.Items.Cast<TPoint>().ToList());
+            this.DefinitionChanged?.Invoke(this.currentDefinition);
+        }
     }
 }

--- a/NohBoard/Forms/Properties/RectangleBoundaryForm.Designer.cs
+++ b/NohBoard/Forms/Properties/RectangleBoundaryForm.Designer.cs
@@ -1,0 +1,132 @@
+﻿namespace ThoNohT.NohBoard.Forms.Properties
+{
+    partial class RectangleBoundaryForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.lblPosition = new System.Windows.Forms.Label();
+            this.lblSize = new System.Windows.Forms.Label();
+            this.btnCancel = new System.Windows.Forms.Button();
+            this.btnApply = new System.Windows.Forms.Button();
+            this.txtSize = new ThoNohT.NohBoard.Controls.VectorTextBox();
+            this.txtPosition = new ThoNohT.NohBoard.Controls.VectorTextBox();
+            this.SuspendLayout();
+            // 
+            // lblPosition
+            // 
+            this.lblPosition.AutoSize = true;
+            this.lblPosition.Location = new System.Drawing.Point(8, 14);
+            this.lblPosition.Name = "lblPosition";
+            this.lblPosition.Size = new System.Drawing.Size(44, 13);
+            this.lblPosition.TabIndex = 0;
+            this.lblPosition.Text = "Position";
+            // 
+            // lblSize
+            // 
+            this.lblSize.AutoSize = true;
+            this.lblSize.Location = new System.Drawing.Point(8, 40);
+            this.lblSize.Name = "lblSize";
+            this.lblSize.Size = new System.Drawing.Size(27, 13);
+            this.lblSize.TabIndex = 1;
+            this.lblSize.Text = "Size";
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.Location = new System.Drawing.Point(35, 63);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(75, 23);
+            this.btnCancel.TabIndex = 4;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            // 
+            // btnApply
+            // 
+            this.btnApply.Location = new System.Drawing.Point(116, 63);
+            this.btnApply.Name = "btnApply";
+            this.btnApply.Size = new System.Drawing.Size(75, 23);
+            this.btnApply.TabIndex = 5;
+            this.btnApply.Text = "Apply";
+            this.btnApply.UseVisualStyleBackColor = true;
+            this.btnApply.Click += new System.EventHandler(this.btnApply_Click);
+            // 
+            // txtSize
+            // 
+            this.txtSize.Location = new System.Drawing.Point(85, 37);
+            this.txtSize.MaxVal = 2147483647;
+            this.txtSize.Name = "txtSize";
+            this.txtSize.Separator = ';';
+            this.txtSize.Size = new System.Drawing.Size(100, 20);
+            this.txtSize.SpacesAroundSeparator = true;
+            this.txtSize.TabIndex = 3;
+            this.txtSize.Text = "0 ; 0";
+            this.txtSize.X = 0;
+            this.txtSize.Y = 0;
+            // 
+            // txtPosition
+            // 
+            this.txtPosition.Location = new System.Drawing.Point(85, 11);
+            this.txtPosition.MaxVal = 2147483647;
+            this.txtPosition.Name = "txtPosition";
+            this.txtPosition.Separator = ';';
+            this.txtPosition.Size = new System.Drawing.Size(100, 20);
+            this.txtPosition.SpacesAroundSeparator = true;
+            this.txtPosition.TabIndex = 2;
+            this.txtPosition.Text = "0 ; 0";
+            this.txtPosition.X = 0;
+            this.txtPosition.Y = 0;
+            // 
+            // RectangleBoundaryForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(203, 96);
+            this.Controls.Add(this.btnApply);
+            this.Controls.Add(this.btnCancel);
+            this.Controls.Add(this.txtSize);
+            this.Controls.Add(this.txtPosition);
+            this.Controls.Add(this.lblSize);
+            this.Controls.Add(this.lblPosition);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
+            this.Name = "RectangleBoundaryForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Rectangle";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label lblPosition;
+        private System.Windows.Forms.Label lblSize;
+        private Controls.VectorTextBox txtPosition;
+        private Controls.VectorTextBox txtSize;
+        private System.Windows.Forms.Button btnCancel;
+        private System.Windows.Forms.Button btnApply;
+    }
+}

--- a/NohBoard/Forms/Properties/RectangleBoundaryForm.cs
+++ b/NohBoard/Forms/Properties/RectangleBoundaryForm.cs
@@ -1,11 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿/*
+Copyright (C) 2016 by Marius Becker <marius.becker.8@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System;
 using System.Windows.Forms;
 
 namespace ThoNohT.NohBoard.Forms.Properties
@@ -30,7 +40,6 @@ namespace ThoNohT.NohBoard.Forms.Properties
         /// <summary>
         /// Creates a new instance and fills the input controls with preset values.
         /// </summary>
-        /// <param name="rectangle"></param>
         public RectangleBoundaryForm(TRectangle rectangle)
         {
             InitializeComponent();

--- a/NohBoard/Forms/Properties/RectangleBoundaryForm.cs
+++ b/NohBoard/Forms/Properties/RectangleBoundaryForm.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace ThoNohT.NohBoard.Forms.Properties
+{
+    using Extra;
+
+    /// <summary>
+    /// The form used to change a key's boundaries to a rectangle.
+    /// </summary>
+    public partial class RectangleBoundaryForm : Form
+    {
+        /// <summary>
+        /// This event is invoked when the user presses the button to save the current dimensions.
+        /// </summary>
+        public event Action<TRectangle> DimensionsSet;
+
+        public RectangleBoundaryForm()
+        {
+            InitializeComponent();
+        }
+
+        /// <summary>
+        /// Creates a new instance and fills the input controls with preset values.
+        /// </summary>
+        /// <param name="rectangle"></param>
+        public RectangleBoundaryForm(TRectangle rectangle)
+        {
+            InitializeComponent();
+
+            var position = rectangle.Position;
+            this.txtPosition.X = position.X;
+            this.txtPosition.Y = position.Y;
+
+            var size = rectangle.Size;
+            this.txtSize.X = size.Width;
+            this.txtSize.Y = size.Height;
+        }
+
+        /// <summary>
+        /// Handles the click event of the "Apply" button. Invokes the DimensionsSet event.
+        /// </summary>
+        private void btnApply_Click(object sender, EventArgs e)
+        {
+            var position = new TPoint(txtPosition.X, txtPosition.Y);
+            var size = new TPoint(txtSize.X, txtSize.Y);
+            var rectangle = new TRectangle(position, size);
+            this.DimensionsSet?.Invoke(rectangle);
+
+            this.DialogResult = DialogResult.OK;
+        }
+
+        /// <summary>
+        /// Handles the click event of the "Cancel" button. Closes the form without invoking any events.
+        /// </summary>
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            this.DialogResult = DialogResult.Cancel;
+        }
+    }
+}

--- a/NohBoard/Forms/Properties/RectangleBoundaryForm.cs
+++ b/NohBoard/Forms/Properties/RectangleBoundaryForm.cs
@@ -15,11 +15,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using System;
-using System.Windows.Forms;
-
 namespace ThoNohT.NohBoard.Forms.Properties
 {
+    using System;
+    using System.Windows.Forms;
     using Extra;
 
     /// <summary>

--- a/NohBoard/Forms/Properties/RectangleBoundaryForm.resx
+++ b/NohBoard/Forms/Properties/RectangleBoundaryForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/NohBoard/NohBoard.csproj
+++ b/NohBoard/NohBoard.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Controls\ColorChooser.Designer.cs">
       <DependentUpon>ColorChooser.cs</DependentUpon>
     </Compile>
+    <Compile Include="Extra\TRectangle.cs" />
     <Compile Include="Forms\Properties\KeyboardKeyPropertiesForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -100,6 +101,12 @@
     </Compile>
     <Compile Include="Forms\Properties\MouseSpeedPropertiesForm.Designer.cs">
       <DependentUpon>MouseSpeedPropertiesForm.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Forms\Properties\RectangleBoundaryForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Forms\Properties\RectangleBoundaryForm.Designer.cs">
+      <DependentUpon>RectangleBoundaryForm.cs</DependentUpon>
     </Compile>
     <Compile Include="Forms\Style\MouseSpeedStyleForm.cs">
       <SubType>Form</SubType>
@@ -207,6 +214,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\Properties\MouseSpeedPropertiesForm.resx">
       <DependentUpon>MouseSpeedPropertiesForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Forms\Properties\RectangleBoundaryForm.resx">
+      <DependentUpon>RectangleBoundaryForm.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\Style\MouseSpeedStyleForm.resx">
       <DependentUpon>MouseSpeedStyleForm.cs</DependentUpon>


### PR DESCRIPTION
# Summary
When merged, this PR adds a dialog that lets the user set keyboard key boundaries by specifying a position and size of a rectangle. Its purpose is to make the creation of rectangular keys, which is the most common type of key, easier.

# Implementation
I added a "Rectangle" button next to the boundary list. When clicked, a new dialog opens that has 2 input controls called "Position" and "Size". The inputs will be pre-populated with the dimensions of a rectangle that surrounds all of the current boundaries of the key.

When the user clicks the "Apply" button in this new dialog, the boundaries of the key are replaced with 4 points that represent the corners of the rectangle.

# Notes
This PR will create conflicts with #69. If you plan to merge both PRs, I'll resolve the conflicts after you merged one of them.

# Screenshots
![grafik](https://user-images.githubusercontent.com/6171432/45932406-f3627a00-bf7b-11e8-97d5-81ab120e7ab1.png)
