### PR TITLE
Change the KeyboardKeyPropertiesForm title to something that's not the default

### DIFF
--- a/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.Designer.cs
+++ b/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.Designer.cs
@@ -326,7 +326,7 @@ namespace ThoNohT.NohBoard.Forms.Properties
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
             this.Name = "KeyboardKeyPropertiesForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "KeyboardKeyPropertiesForm";
+            this.Text = "Keyboard Key Properties";
             this.Load += new System.EventHandler(this.KeyboardKeyPropertiesForm_Load);
             ((System.ComponentModel.ISupportInitialize)(this.udKeyCode)).EndInit();
             this.ResumeLayout(false);


### PR DESCRIPTION
This one is pretty straight forward. The form's title was still "KeyboardKeyPropertiesForm". I changed it to "Keyboard Key Properties".