### PR TITLE
Update all copyright headers with the current year

### DIFF
--- a/Hooking/CircleBuffer.cs
+++ b/Hooking/CircleBuffer.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/Hooking/Interop/Defines.cs
+++ b/Hooking/Interop/Defines.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/Hooking/Interop/FunctionImports.cs
+++ b/Hooking/Interop/FunctionImports.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/Hooking/Interop/HookManager.Public.cs
+++ b/Hooking/Interop/HookManager.Public.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/Hooking/Interop/HookManager.cs
+++ b/Hooking/Interop/HookManager.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/Hooking/Interop/Structs.cs
+++ b/Hooking/Interop/Structs.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/Hooking/KeyboardState.cs
+++ b/Hooking/KeyboardState.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/Hooking/MouseKeyCode.cs
+++ b/Hooking/MouseKeyCode.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/Hooking/MouseScrollKeyCode.cs
+++ b/Hooking/MouseScrollKeyCode.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/Hooking/MouseState.cs
+++ b/Hooking/MouseState.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/Hooking/Properties/AssemblyInfo.cs.template
+++ b/Hooking/Properties/AssemblyInfo.cs.template
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("ThoNohT")]
 [assembly: AssemblyProduct("NohBoard Hooking Library")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/NohBoard/Constants.cs
+++ b/NohBoard/Constants.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Controls/ColorChooser.cs
+++ b/NohBoard/Controls/ColorChooser.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Controls/FontChooser.cs
+++ b/NohBoard/Controls/FontChooser.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Controls/KeySubStylePanel.cs
+++ b/NohBoard/Controls/KeySubStylePanel.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Controls/MouseSpeedStylePanel.cs
+++ b/NohBoard/Controls/MouseSpeedStylePanel.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Controls/VectorTextBox.cs
+++ b/NohBoard/Controls/VectorTextBox.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Extra/CapitalizationMethod.cs
+++ b/NohBoard/Extra/CapitalizationMethod.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Extra/FileHelper.cs
+++ b/NohBoard/Extra/FileHelper.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Extra/GlobalSettings.cs
+++ b/NohBoard/Extra/GlobalSettings.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Extra/ImageCache.cs
+++ b/NohBoard/Extra/ImageCache.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Extra/ListHelpers.cs
+++ b/NohBoard/Extra/ListHelpers.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Extra/SerializableColor.cs
+++ b/NohBoard/Extra/SerializableColor.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Extra/SerializableFont.cs
+++ b/NohBoard/Extra/SerializableFont.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Extra/TPoint.cs
+++ b/NohBoard/Extra/TPoint.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Extra/TRectangle.cs
+++ b/NohBoard/Extra/TRectangle.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Marius Becker <marius.becker.8@gmail.com>
+Copyright (C) 2018 by Marius Becker <marius.becker.8@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/ColorChooser.cs
+++ b/NohBoard/Forms/ColorChooser.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/FontChooser.cs
+++ b/NohBoard/Forms/FontChooser.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/LoadKeyboardForm.Designer.cs
+++ b/NohBoard/Forms/LoadKeyboardForm.Designer.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/LoadKeyboardForm.cs
+++ b/NohBoard/Forms/LoadKeyboardForm.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/MainForm.Designer.cs
+++ b/NohBoard/Forms/MainForm.Designer.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/MainForm.Editmode.cs
+++ b/NohBoard/Forms/MainForm.Editmode.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/MainForm.cs
+++ b/NohBoard/Forms/MainForm.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.Designer.cs
+++ b/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.Designer.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2017 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.cs
+++ b/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2017 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/Properties/KeyboardPropertiesForm.Designer.cs
+++ b/NohBoard/Forms/Properties/KeyboardPropertiesForm.Designer.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2017 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/Properties/KeyboardPropertiesForm.cs
+++ b/NohBoard/Forms/Properties/KeyboardPropertiesForm.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2017 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/Properties/MouseElementPropertiesForm.Designer.cs
+++ b/NohBoard/Forms/Properties/MouseElementPropertiesForm.Designer.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2017 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/Properties/MouseElementPropertiesForm.cs
+++ b/NohBoard/Forms/Properties/MouseElementPropertiesForm.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2017 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/Properties/MouseSpeedPropertiesForm.Designer.cs
+++ b/NohBoard/Forms/Properties/MouseSpeedPropertiesForm.Designer.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2017 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/Properties/MouseSpeedPropertiesForm.cs
+++ b/NohBoard/Forms/Properties/MouseSpeedPropertiesForm.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2017 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/Properties/RectangleBoundaryForm.Designer.cs
+++ b/NohBoard/Forms/Properties/RectangleBoundaryForm.Designer.cs
@@ -1,4 +1,21 @@
-﻿namespace ThoNohT.NohBoard.Forms.Properties
+﻿/*
+Copyright (C) 2018 by Marius Becker <marius.becker.8@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace ThoNohT.NohBoard.Forms.Properties
 {
     partial class RectangleBoundaryForm
     {
@@ -35,27 +52,27 @@
             this.txtSize = new ThoNohT.NohBoard.Controls.VectorTextBox();
             this.txtPosition = new ThoNohT.NohBoard.Controls.VectorTextBox();
             this.SuspendLayout();
-            // 
+            //
             // lblPosition
-            // 
+            //
             this.lblPosition.AutoSize = true;
             this.lblPosition.Location = new System.Drawing.Point(8, 14);
             this.lblPosition.Name = "lblPosition";
             this.lblPosition.Size = new System.Drawing.Size(44, 13);
             this.lblPosition.TabIndex = 0;
             this.lblPosition.Text = "Position";
-            // 
+            //
             // lblSize
-            // 
+            //
             this.lblSize.AutoSize = true;
             this.lblSize.Location = new System.Drawing.Point(8, 40);
             this.lblSize.Name = "lblSize";
             this.lblSize.Size = new System.Drawing.Size(27, 13);
             this.lblSize.TabIndex = 1;
             this.lblSize.Text = "Size";
-            // 
+            //
             // btnCancel
-            // 
+            //
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.btnCancel.Location = new System.Drawing.Point(35, 63);
             this.btnCancel.Name = "btnCancel";
@@ -64,9 +81,9 @@
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
             this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
-            // 
+            //
             // btnApply
-            // 
+            //
             this.btnApply.Location = new System.Drawing.Point(116, 63);
             this.btnApply.Name = "btnApply";
             this.btnApply.Size = new System.Drawing.Size(75, 23);
@@ -74,9 +91,9 @@
             this.btnApply.Text = "Apply";
             this.btnApply.UseVisualStyleBackColor = true;
             this.btnApply.Click += new System.EventHandler(this.btnApply_Click);
-            // 
+            //
             // txtSize
-            // 
+            //
             this.txtSize.Location = new System.Drawing.Point(85, 37);
             this.txtSize.MaxVal = 2147483647;
             this.txtSize.Name = "txtSize";
@@ -87,9 +104,9 @@
             this.txtSize.Text = "0 ; 0";
             this.txtSize.X = 0;
             this.txtSize.Y = 0;
-            // 
+            //
             // txtPosition
-            // 
+            //
             this.txtPosition.Location = new System.Drawing.Point(85, 11);
             this.txtPosition.MaxVal = 2147483647;
             this.txtPosition.Name = "txtPosition";
@@ -100,9 +117,9 @@
             this.txtPosition.Text = "0 ; 0";
             this.txtPosition.X = 0;
             this.txtPosition.Y = 0;
-            // 
+            //
             // RectangleBoundaryForm
-            // 
+            //
             this.AcceptButton = this.btnApply;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;

--- a/NohBoard/Forms/Properties/RectangleBoundaryForm.cs
+++ b/NohBoard/Forms/Properties/RectangleBoundaryForm.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Marius Becker <marius.becker.8@gmail.com>
+Copyright (C) 2018 by Marius Becker <marius.becker.8@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/SaveKeyboardAsForm.Designer.cs
+++ b/NohBoard/Forms/SaveKeyboardAsForm.Designer.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/SaveKeyboardAsForm.cs
+++ b/NohBoard/Forms/SaveKeyboardAsForm.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/SaveStyleAsForm.Designer.cs
+++ b/NohBoard/Forms/SaveStyleAsForm.Designer.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/SaveStyleAsForm.cs
+++ b/NohBoard/Forms/SaveStyleAsForm.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/SettingsForm.Designer.cs
+++ b/NohBoard/Forms/SettingsForm.Designer.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/SettingsForm.cs
+++ b/NohBoard/Forms/SettingsForm.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/Style/KeyStyleForm.Designer.cs
+++ b/NohBoard/Forms/Style/KeyStyleForm.Designer.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/Style/KeyStyleForm.cs
+++ b/NohBoard/Forms/Style/KeyStyleForm.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/Style/KeyboardStyleForm.Designer.cs
+++ b/NohBoard/Forms/Style/KeyboardStyleForm.Designer.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/Style/KeyboardStyleForm.cs
+++ b/NohBoard/Forms/Style/KeyboardStyleForm.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/Style/MouseSpeedStyleForm.Designer.cs
+++ b/NohBoard/Forms/Style/MouseSpeedStyleForm.Designer.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Forms/Style/MouseSpeedStyleForm.cs
+++ b/NohBoard/Forms/Style/MouseSpeedStyleForm.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Keyboard/ElementDefinitions/ElementDefinition.cs
+++ b/NohBoard/Keyboard/ElementDefinitions/ElementDefinition.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Keyboard/ElementDefinitions/ElementManipulation.cs
+++ b/NohBoard/Keyboard/ElementDefinitions/ElementManipulation.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Keyboard/ElementDefinitions/KeyDefinition.cs
+++ b/NohBoard/Keyboard/ElementDefinitions/KeyDefinition.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Keyboard/ElementDefinitions/KeyboardKeyDefinition.cs
+++ b/NohBoard/Keyboard/ElementDefinitions/KeyboardKeyDefinition.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Keyboard/ElementDefinitions/MouseKeyDefinition.cs
+++ b/NohBoard/Keyboard/ElementDefinitions/MouseKeyDefinition.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Keyboard/ElementDefinitions/MouseScrollDefinition.cs
+++ b/NohBoard/Keyboard/ElementDefinitions/MouseScrollDefinition.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Keyboard/ElementDefinitions/MouseSpeedIndicatorDefinition.cs
+++ b/NohBoard/Keyboard/ElementDefinitions/MouseSpeedIndicatorDefinition.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Keyboard/KeyboardDefinition.cs
+++ b/NohBoard/Keyboard/KeyboardDefinition.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Keyboard/KeyboardStyle.cs
+++ b/NohBoard/Keyboard/KeyboardStyle.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Keyboard/Styles/ElementStyle.cs
+++ b/NohBoard/Keyboard/Styles/ElementStyle.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Keyboard/Styles/KeyStyle.cs
+++ b/NohBoard/Keyboard/Styles/KeyStyle.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Keyboard/Styles/KeySubStyle.cs
+++ b/NohBoard/Keyboard/Styles/KeySubStyle.cs
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Keyboard/Styles/MouseSpeedIndicatorStyle.cs
+++ b/NohBoard/Keyboard/Styles/MouseSpeedIndicatorStyle.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Legacy/KeyType.cs
+++ b/NohBoard/Legacy/KeyType.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Legacy/LegacyCharacterMapping.cs
+++ b/NohBoard/Legacy/LegacyCharacterMapping.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Legacy/LegacyFileParseException.cs
+++ b/NohBoard/Legacy/LegacyFileParseException.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Legacy/LegacyKbFileParser.cs
+++ b/NohBoard/Legacy/LegacyKbFileParser.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Legacy/LegacyKeyCodeMapping.cs
+++ b/NohBoard/Legacy/LegacyKeyCodeMapping.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Program.cs
+++ b/NohBoard/Program.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/Properties/AssemblyInfo.cs.template
+++ b/NohBoard/Properties/AssemblyInfo.cs.template
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("ThoNohT")]
 [assembly: AssemblyProduct("NohBoard Application")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/NohBoard/Version.cs.template
+++ b/NohBoard/Version.cs.template
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/NohBoard/VersionInfo.cs
+++ b/NohBoard/VersionInfo.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (C) 2016 by Eric Bataille <e.c.p.bataille@gmail.com>
+Copyright (C) 2018 by Eric Bataille <e.c.p.bataille@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
When merged, this PR will change all the years in copyright headers to 2018. Some of them said 2017 and the majority said 2016.

This would fix #82.