### PR TITLE
Add options to prevent the main form from minimizing

### DIFF
--- a/NohBoard/NohBoard/Forms/MainForm.Designer.cs
+++ b/NohBoard/NohBoard/Forms/MainForm.Designer.cs
@@ -50,6 +50,7 @@ namespace ThoNohT.NohBoard.Forms
             this.UpdateTimer = new System.Windows.Forms.Timer(this.components);
             this.MainMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.mnuSettings = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnuPreventMinimize = new System.Windows.Forms.ToolStripMenuItem();
             this.mnuKeyboards = new System.Windows.Forms.ToolStripMenuItem();
             this.MainMenuSep2 = new System.Windows.Forms.ToolStripSeparator();
             this.mnuToggleEditMode = new System.Windows.Forms.ToolStripMenuItem();
@@ -98,6 +99,7 @@ namespace ThoNohT.NohBoard.Forms
             this.MainMenu.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.MainMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.mnuSettings,
+            this.mnuPreventMinimize,
             this.mnuKeyboards,
             this.MainMenuSep2,
             this.mnuToggleEditMode,
@@ -129,6 +131,13 @@ namespace ThoNohT.NohBoard.Forms
             this.mnuSettings.Size = new System.Drawing.Size(202, 22);
             this.mnuSettings.Text = "&Settings";
             this.mnuSettings.Click += new System.EventHandler(this.mnuSettings_Click);
+            //
+            // mnuPreventMinimize
+            //
+            this.mnuPreventMinimize.Name = "mnuPreventMinimize";
+            this.mnuPreventMinimize.Size = new System.Drawing.Size(202, 22);
+            this.mnuPreventMinimize.Text = "&Prevent NohBoard minimizes";
+            this.mnuPreventMinimize.Click += new System.EventHandler(this.mnuPreventMinimize_Click);
             // 
             // mnuKeyboards
             // 
@@ -422,6 +431,7 @@ namespace ThoNohT.NohBoard.Forms
         private System.Windows.Forms.ContextMenuStrip MainMenu;
         private System.Windows.Forms.ToolStripMenuItem mnuKeyboards;
         private System.Windows.Forms.ToolStripMenuItem mnuSettings;
+        private System.Windows.Forms.ToolStripMenuItem mnuPreventMinimize;
         private System.Windows.Forms.ToolStripSeparator MainMenuSep1;
         private System.Windows.Forms.ToolStripMenuItem mnuToggleEditMode;
         private System.Windows.Forms.ToolStripMenuItem mnuSaveStyle;

--- a/NohBoard/NohBoard/Forms/MainForm.cs
+++ b/NohBoard/NohBoard/Forms/MainForm.cs
@@ -584,6 +584,26 @@ namespace ThoNohT.NohBoard.Forms
         #region Rendering
 
         /// <summary>
+        /// Whether the main form can be minimized or not. A minimized form will not call OnPaint upon Refresh.
+        /// This makes sure that OnPaint is always called by Refresh.
+        /// </summary>
+        private bool PreventMinimize;
+
+        private void mnuPreventMinimize_Click(object sender, EventArgs e)
+        {
+            this.PreventMinimize = !this.PreventMinimize;
+            if (this.PreventMinimize)
+            {
+                this.MinimizeBox = false;
+                this.mnuPreventMinimize.Checked = true;
+            }
+            else
+            {
+                this.MinimizeBox = true;
+                this.mnuPreventMinimize.Checked = false;
+            }
+        }
+        /// <summary>
         /// Paints the keyboard on the screen.
         /// </summary>
         protected override void OnPaint(PaintEventArgs e)
@@ -685,10 +705,13 @@ namespace ThoNohT.NohBoard.Forms
         }
 
         /// <summary>
-        /// Forces an update if any of the key or mouse states have changed.
+        /// Forces an update if any of the key or mouse states have changed, and makes sure that the form is not
+        /// minimized if PreventMinimize is on.
         /// </summary>
         private void UpdateTimer_Tick(object sender, EventArgs e)
         {
+            if (this.WindowState == FormWindowState.Minimized && this.PreventMinimize)
+                this.WindowState = FormWindowState.Normal;
             if (KeyboardState.Updated || MouseState.Updated)
                 this.Refresh();
         }


### PR DESCRIPTION
If a form is minimized, `Refresh()` does not trigger `OnPaint()`, so a solution is to prevent the form from minimizing in the first place.