### PR TITLE
Add Or Mode for KeyboardKeyDefinitions

### DIFF
--- a/NohBoard/NohBoard/Forms/MainForm.cs
+++ b/NohBoard/NohBoard/Forms/MainForm.cs
@@ -17,704 +17,723 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace ThoNohT.NohBoard.Forms
 {
-    using Extra;
-    using Hooking;
-    using Hooking.Interop;
-    using Keyboard;
-    using Keyboard.ElementDefinitions;
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Drawing;
-    using System.Drawing.Text;
-    using System.Linq;
-    using System.Net.Http;
-    using System.Runtime.Serialization.Json;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Windows.Forms;
-    using System.Xml;
-    using ThoNohT.NohBoard.Keyboard.Styles;
-    using Version = NohBoard.Version;
-
-    /// <summary>
-    /// The main form.
-    /// </summary>
-    public partial class MainForm : Form
-    {
-        #region Fields
-
-        /// <summary>
-        /// The back-brushes used for efficient drawing.
-        /// </summary>
-        private readonly Dictionary<bool, Dictionary<bool, Brush>> backBrushes =
-            new Dictionary<bool, Dictionary<bool, Brush>>();
-
-        /// <summary>
-        /// The element currently under the cursor.
-        /// </summary>
-        private ElementDefinition elementUnderCursor = null;
-
-        /// <summary>
-        /// The latest version, if it was retrieved from the update site.
-        /// </summary>
-        private VersionInfo latestVersion = null;
-
-        #endregion Fields
-
-        #region Constructors
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MainForm" /> class.
-        /// </summary>
-        public MainForm()
-        {
-            this.InitializeComponent();
-            this.SetStyle(ControlStyles.ResizeRedraw, true);
-        }
-
-        #endregion Constructors
-
-        #region Version check
-
-        /// <summary>
-        /// Attempts to retrieve the latest version from the update site.
-        /// </summary>
-        public Task GetLatestVersion()
-        {
-            return new Task(
-                () =>
-                {
-                    var updateUrl =
-                        "https://gist.githubusercontent.com/ThoNohT/3181561f8148fb6b865f88714e975154/raw/nohboard_version.json";
-
-                    VersionInfo downloadVersionInfo(string url)
-                    {
-                        var serializer = new DataContractJsonSerializer(typeof(VersionInfo));
-                        using (var client = new HttpClient())
-                        using (var reader = JsonReaderWriterFactory.CreateJsonReader(
-                            client.GetStreamAsync(updateUrl).Result,
-                            Encoding.UTF8,
-                            XmlDictionaryReaderQuotas.Max,
-                            dictionaryReader => { }))
-                        {
-                            return (VersionInfo)serializer.ReadObject(reader);
-                        }
-                    }
-
-                    var versionInfo = downloadVersionInfo(updateUrl);
-
-                    if ((versionInfo.Major > Version.Major) ||
-                        (versionInfo.Major == Version.Major && versionInfo.Minor > Version.Minor) ||
-                        (versionInfo.Major == Version.Major && versionInfo.Minor == Version.Minor
-                         && versionInfo.Patch > Version.Patch))
-                    {
-                        this.latestVersion = versionInfo;
-                    }
-                });
-        }
-
-        #endregion Version check
-
-        #region Keyboard loading and saving
-
-        /// <summary>
-        /// Loads the keyboard currently defined in the settings.
-        /// </summary>
-        /// <returns>The list of fonts that are not present on this system and might be downloaded for this keyboard.
-        /// </returns>
-        private List<SerializableFont> LoadKeyboard()
-        {
-            if (GlobalSettings.CurrentDefinition == null)
-            {
-                HookManager.DisableKeyboardHook();
-                HookManager.DisableMouseHook();
-
-                return new List<SerializableFont>();
-            }
-            // Enable the mouse hook only if there are mouse keys on the screen.
-            if (GlobalSettings.CurrentDefinition.Elements.Any(x => !(x is KeyboardKeyDefinition)))
-                HookManager.EnableMouseHook();
-            else
-                HookManager.DisableMouseHook();
-
-            // Enable the keyboard hook only if there are keyboard keys on the screen.
-            if (GlobalSettings.CurrentDefinition.Elements.Any(x => x is KeyboardKeyDefinition))
-                HookManager.EnableKeyboardHook();
-            else
-                HookManager.DisableKeyboardHook();
-
-            //Prompt to download any fonts we don't have yet.
-            var missingFonts = this.CheckMissingFonts();
-
-            GlobalSettings.Settings.InitUndoHistory();
-
-            // Reset all edit mode related fields, as we should be no longer in edit mode.
-            if (this.mnuToggleEditMode.Checked)
-            {
-                this.mnuToggleEditMode.Checked = false;
-                this.mnuToggleEditMode_Click(null, null);
-            }
-
-            this.currentlyManipulating = null;
-            this.highlightedDefinition = null;
-            this.selectedDefinition = null;
-
-            this.ClientSize = new Size(GlobalSettings.CurrentDefinition.Width, GlobalSettings.CurrentDefinition.Height);
-
-            this.ResetBackBrushes();
-
-            return missingFonts;
-        }
-
-        /// <summary>
-        /// Checks if there are any fonts that are not on the system, and do have a download link in them. If this is
-        /// the case, then those fonts are returned.
-        /// </summary>
-        /// <returns>The list of fonts that are not present and might be downloaded. Missing fonts without a download
-        /// link are also returned.</returns>
-        private List<SerializableFont> CheckMissingFonts()
-        {
-            var style = GlobalSettings.CurrentStyle;
-            var usedFonts = style.ElementStyles.Values.OfType<KeyStyle>()
-                .SelectMany(s => new[] { s.Loose?.Font, s.Pressed?.Font })
-                .Union(new[] { style.DefaultKeyStyle?.Loose?.Font, style.DefaultKeyStyle?.Pressed?.Font })
-                .Where(f => f != null).ToList();
-
-            var installedFonts = new InstalledFontCollection();
-            var installedFontFamilyNames = new HashSet<string>(installedFonts.Families.Select(f => f.Name));
-            var notInstalledUsedFonts = usedFonts.Where(f => !installedFontFamilyNames.Contains(f.FontFamily)).ToList();
-
-            foreach (var font in notInstalledUsedFonts)
-            {
-                // For now, update the used family to the default. Next time they could have downloaded the font.
-                font.AlternateFontFamily = SystemFonts.DefaultFont.FontFamily.Name;
-            }
-
-            if (!notInstalledUsedFonts.Any()) return new List<SerializableFont>();
-
-            return notInstalledUsedFonts.OrderBy(f => f.DownloadUrl == null).Distinct(new SerializableFont.FamilyComparer()).ToList();
-        }
-
-        /// <summary>
-        /// Redraws the back-brushes. These back-brushes are drawn for all possible states of the keys when none of them
-        /// are pressed. This prevents having to render each of these keys every time. However, every time anything
-        /// about the definition or style changes, the back-brushes have to be re-rendered.
-        /// </summary>
-        private void ResetBackBrushes()
-        {
-            GlobalSettings.StyleDependencyCounter++;
-
-            foreach (var brush in this.backBrushes)
-            {
-                foreach (var b in brush.Value)
-                    b.Value.Dispose();
-
-                brush.Value.Clear();
-            }
-            this.backBrushes.Clear();
-
-            // Fill the back-brushes.
-            foreach (var shift in new[] { false, true })
-            {
-                this.backBrushes.Add(shift, new Dictionary<bool, Brush>());
-
-                foreach (var caps in new[] { false, true })
-                {
-                    var bmp = new Bitmap(
-                        GlobalSettings.CurrentDefinition.Width,
-                        GlobalSettings.CurrentDefinition.Height);
-                    var g = Graphics.FromImage(bmp);
-
-                    // Render the background image if set.
-                    var cs = GlobalSettings.CurrentStyle;
-                    if (cs.BackgroundImageFileName != null && FileHelper.StyleImageExists(cs.BackgroundImageFileName))
-                    {
-                        g.DrawImage(ImageCache.Get(cs.BackgroundImageFileName), this.ClientRectangle);
-                    }
-
-                    // Render the individual keys.
-                    foreach (var def in GlobalSettings.CurrentDefinition.Elements)
-                    {
-                        if (def is KeyboardKeyDefinition) ((KeyboardKeyDefinition)def).Render(g, false, shift, caps);
-
-                        if (def is MouseKeyDefinition) ((MouseKeyDefinition)def).Render(g, false, shift, caps);
-
-                        if (def is MouseScrollDefinition) ((MouseScrollDefinition)def).Render(g, 0);
-
-                        // No need to render mouse speed indicators in backbrush.
-                    }
-
-                    this.backBrushes[shift].Add(caps, new TextureBrush(bmp));
-                }
-            }
-
-            this.Refresh();
-        }
-
-        /// <summary>
-        /// Opens the load keyboard form.
-        /// </summary>
-        private void mnuLoadKeyboard_Click(object sender, EventArgs e)
-        {
-            if (GlobalSettings.UnsavedDefinitionChanges || GlobalSettings.UnsavedStyleChanges)
-            {
-                var result = MessageBox.Show(
-                    "You have unsaved changes. Loading a new keyboard will undo them. Are you sure you want to load a new keyboard?",
-                    "Discard changes",
-                    MessageBoxButtons.OKCancel,
-                    MessageBoxIcon.Warning);
-
-                if (result != DialogResult.OK) return;
-            }
-
-            this.menuOpen = false;
-
-            using (var manageForm = new LoadKeyboardForm())
-            {
-                manageForm.DefinitionChanged += (kbDef, kbStyle, globalStyle) =>
-                {
-                    var backupDef = GlobalSettings.CurrentDefinition;
-                    var backupStyle = GlobalSettings.CurrentStyle;
-
-                    var backupCat = GlobalSettings.Settings.LoadedCategory;
-                    var backupKb = GlobalSettings.Settings.LoadedKeyboard;
-                    var backupKbStyle = GlobalSettings.Settings.LoadedStyle;
-                    var backupkbGlobalStyle = GlobalSettings.Settings.LoadedGlobalStyle;
-
-                    // Don't worry about undo history, it will be initialized alter in LoadKeyboard.
-                    GlobalSettings.Settings.UpdateDefinition(kbDef, false);
-                    GlobalSettings.Settings.UpdateStyle(kbStyle ?? new KeyboardStyle(), false);
-
-                    GlobalSettings.Settings.LoadedCategory = kbDef.Category;
-                    GlobalSettings.Settings.LoadedKeyboard = kbDef.Name;
-                    GlobalSettings.Settings.LoadedStyle = kbStyle?.Name;
-                    GlobalSettings.Settings.LoadedGlobalStyle = globalStyle;
-
-                    try
-                    {
-                        var missingFonts = this.LoadKeyboard();
-                        manageForm.ToggleFontsPanel(missingFonts);
-                    }
-                    catch (Exception ex)
-                    {
-                        GlobalSettings.Settings.UpdateDefinition(backupDef, false);
-                        GlobalSettings.Settings.UpdateStyle(backupStyle, false);
-
-                        GlobalSettings.Settings.LoadedCategory = backupCat;
-                        GlobalSettings.Settings.LoadedKeyboard = backupKb;
-                        GlobalSettings.Settings.LoadedStyle = backupKbStyle;
-                        GlobalSettings.Settings.LoadedGlobalStyle = backupkbGlobalStyle;
-
-                        this.LoadKeyboard();
-
-                        MessageBox.Show(ex.Message + Environment.NewLine + "Reverted keyboard change.");
-                    }
-                };
-
-                manageForm.ShowDialog(this);
-            }
-        }
-
-        /// <summary>
-        /// Saves the current definition under its default name.
-        /// </summary>
-        private void mnuSaveDefinitionAsName_Click(object sender, EventArgs e)
-        {
-            this.menuOpen = false;
-
-            GlobalSettings.CurrentDefinition.Save();
-            GlobalSettings.Settings.LoadedCategory = GlobalSettings.CurrentDefinition.Category;
-            GlobalSettings.Settings.LoadedKeyboard = GlobalSettings.CurrentDefinition.Name;
-        }
-
-        /// <summary>
-        /// Opens a form the save the current definition under a custom name.
-        /// </summary>
-        private void mnuSaveDefinitionAs_Click(object sender, EventArgs e)
-        {
-            this.menuOpen = false;
-
-            using (var saveForm = new SaveKeyboardAsForm())
-            {
-                saveForm.ShowDialog(this);
-            }
-        }
-
-        #endregion Keyboard loading and saving
-
-        #region Settings
-
-        /// <summary>
-        /// Handles the loading of the form, all settings are read, hooks are created and the keyboard is initialized.
-        /// </summary>
-        private void MainForm_Load(object sender, EventArgs e)
-        {
-            // Load the settings
-            if (!GlobalSettings.Load())
-            {
-                MessageBox.Show(
-                    this,
-                    $"Failed to load the settings: {GlobalSettings.Errors}",
-                    "Failed to load settings");
-            }
-
-            this.Location = new Point(GlobalSettings.Settings.X, GlobalSettings.Settings.Y);
-            var title = GlobalSettings.Settings.WindowTitle;
-
-            this.Text = string.IsNullOrWhiteSpace(title) ? $"NohBoard {Version.Get}" : title;
-
-            this.GetLatestVersion().Start();
-
-            // Load a definition if possible.
-            if (GlobalSettings.Settings.LoadedKeyboard != null && GlobalSettings.Settings.LoadedCategory != null)
-            {
-                try
-                {
-                    GlobalSettings.Settings.UpdateDefinition(KeyboardDefinition
-                        .Load(GlobalSettings.Settings.LoadedCategory, GlobalSettings.Settings.LoadedKeyboard), false);
-                }
-                catch (Exception ex)
-                {
-                    MessageBox.Show(
-                        "There was an error loading the saved keyboard definition file:" +
-                        $"{Environment.NewLine}{ex.Message}");
-                    GlobalSettings.Settings.LoadedCategory = null;
-                    GlobalSettings.Settings.LoadedKeyboard = null;
-                }
-            }
-
-            // Load a style if possible.
-            if (GlobalSettings.CurrentDefinition != null && GlobalSettings.Settings.LoadedStyle != null)
-            {
-                try
-                {
-                    GlobalSettings.Settings.UpdateStyle(KeyboardStyle.Load(
-                        GlobalSettings.Settings.LoadedStyle,
-                        GlobalSettings.Settings.LoadedGlobalStyle), false);
-                    this.LoadKeyboard();
-                    this.ResetBackBrushes();
-                }
-                catch
-                {
-                    GlobalSettings.Settings.LoadedStyle = null;
-                    MessageBox.Show(
-                        $"Failed to load style {GlobalSettings.Settings.LoadedStyle}, loading default style.",
-                        "Error loading style.");
-                }
-
-                // Enable the mouse hook only if there are mouse keys on the screen.
-                if (GlobalSettings.CurrentDefinition.Elements.Any(x => !(x is KeyboardKeyDefinition)))
-                    HookManager.EnableMouseHook();
-
-                // Enable the keyboard hook only if there are keyboard keys on the screen.
-                if (GlobalSettings.CurrentDefinition.Elements.Any(x => x is KeyboardKeyDefinition))
-                    HookManager.EnableKeyboardHook();
-            }
-
-            this.UpdateTimer.Interval = GlobalSettings.Settings.UpdateInterval;
-            this.UpdateTimer.Enabled = true;
-            this.KeyCheckTimer.Enabled = true;
-
-            this.Activate();
-            this.ApplySettings();
-        }
-
-        /// <summary>
-        /// Handles the moving of the form. Stores the current position for future use.
-        /// </summary>
-        private void MainForm_Move(object sender, EventArgs e)
-        {
-            if (GlobalSettings.Settings != null && this.WindowState == FormWindowState.Normal)
-            {
-                GlobalSettings.Settings.X = this.Location.X;
-                GlobalSettings.Settings.Y = this.Location.Y;
-            }
-        }
-
-        /// <summary>
-        /// Handles the closing of the form. Hooks are disabled and the settings are saved before closing.
-        /// </summary>
-        private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
-        {
-            if (GlobalSettings.UnsavedDefinitionChanges || GlobalSettings.UnsavedStyleChanges && !CrashHandler.Crashed)
-            {
-                var result = MessageBox.Show(
-                    "You have unsaved changes. If you exit now you will lose them. Are you sure you want to exit?",
-                    "Discard changes",
-                    MessageBoxButtons.OKCancel,
-                    MessageBoxIcon.Warning);
-
-                if (result != DialogResult.OK)
-                {
-                    e.Cancel = true;
-                    return;
-                }
-            }
-
-            HookManager.DisableMouseHook();
-            HookManager.DisableKeyboardHook();
-
-            GlobalSettings.Save();
-        }
-
-        /// <summary>
-        /// Applies the currently stored settings.
-        /// </summary>
-        private void ApplySettings()
-        {
-            HookManager.TrapKeyboard = GlobalSettings.Settings.TrapKeyboard;
-            HookManager.TrapMouse = GlobalSettings.Settings.TrapMouse;
-            HookManager.TrapToggleKeyCode = GlobalSettings.Settings.TrapToggleKeyCode;
-            HookManager.ScrollHold = GlobalSettings.Settings.ScrollHold;
-            HookManager.PressHold = GlobalSettings.Settings.PressHold;
-
-            var title = GlobalSettings.Settings.WindowTitle;
-            this.Text = string.IsNullOrWhiteSpace(title) ? $"NohBoard {Version.Get}" : title;
-
-            this.LoadKeyboard();
-        }
-
-        /// <summary>
-        /// Opens the settings form.
-        /// </summary>
-        private void mnuSettings_Click(object sender, EventArgs e)
-        {
-            this.menuOpen = false;
-
-            using (var settingsForm = new SettingsForm())
-            {
-                var result = settingsForm.ShowDialog(this);
-
-                if (result == DialogResult.Cancel)
-                    return;
-
-                // Re-initialize with the new settings.
-                this.ApplySettings();
-            }
-        }
-
-        /// <summary>
-        /// Populates the main menu. Elements are visible based on which definitions and styles are loaded, and whether
-        /// actions on a specifically pointed element are possible.
-        /// </summary>
-        private void MainMenu_Opening(object sender, System.ComponentModel.CancelEventArgs e)
-        {
-            this.menuOpen = true;
-
-            this.mnuSaveDefinition.Enabled = GlobalSettings.CurrentDefinition != null;
-            if (GlobalSettings.CurrentDefinition != null)
-            {
-                this.mnuSaveDefinitionAsName.Text =
-                    $"Save &To '{GlobalSettings.CurrentDefinition.Category}/{GlobalSettings.CurrentDefinition.Name}'";
-
-                var mousePos = this.PointToClient(Cursor.Position);
-                this.elementUnderCursor =
-                    GlobalSettings.CurrentDefinition.Elements.FirstOrDefault(x => x.Inside(mousePos));
-
-                // Set the highlighted definition only if we're in edit mode, and there is not an already selected definition.
-                if (this.mnuToggleEditMode.Checked && this.selectedDefinition == null)
-                {
-                    this.highlightedDefinition = this.elementUnderCursor;
-                    this.highlightedDefinition?.StartManipulating(mousePos, false);
-                }
-
-                var relevantElement = this.selectedDefinition ?? this.elementUnderCursor;
-                this.mnuEditElementStyle.Enabled = relevantElement != null;
-                this.mnuElementProperties.Enabled = relevantElement != null;
-            }
-
-            // Only allow editing of properties/styles in edit mode.
-            this.mnuKeyboardProperties.Visible = this.mnuToggleEditMode.Checked;
-            this.mnuUpdateTextPosition.Visible = this.mnuToggleEditMode.Checked;
-            this.mnuElementProperties.Visible = this.mnuToggleEditMode.Checked;
-            this.mnuEditKeyboardStyle.Visible = this.mnuToggleEditMode.Checked;
-            this.mnuEditElementStyle.Visible = this.mnuToggleEditMode.Checked;
-            this.MainMenuSep1.Visible = this.mnuToggleEditMode.Checked;
-
-            this.mnuSaveStyleToName.Text = $"Save &To '{GlobalSettings.CurrentStyle.Name}'";
-            this.mnuSaveStyleToName.Visible = !GlobalSettings.Settings.LoadedGlobalStyle;
-            this.mnuSaveToGlobalStyleName.Text = $"Save To &Global '{GlobalSettings.CurrentStyle.Name}'";
-            this.mnuSaveToGlobalStyleName.Enabled = GlobalSettings.CurrentStyle.IsGlobal;
-            this.mnuSaveToGlobalStyleName.Visible = GlobalSettings.Settings.LoadedGlobalStyle;
-
-            this.mnuToggleEditMode.Enabled = GlobalSettings.CurrentDefinition != null;
-
-            if (this.latestVersion != null && !this.mnuUpdate.Visible)
-            {
-                this.mnuUpdate.Text = $"New version available: {this.latestVersion.Format()}.";
-                this.mnuUpdate.Visible = true;
-                this.mnuUpdate.Click += (s, ea) => { Process.Start(new ProcessStartInfo { FileName = "https://github.com/ThoNohT/NohBoard/releases", UseShellExecute = true }); };
-            }
-
-            this.mnuMoveElement.Visible = this.relevantDefinition != null;
-
-            var highlightedSomething = this.mnuToggleEditMode.Checked && this.relevantDefinition != null;
-
-            // Edit mode related menu items.
-            this.mnuAddBoundaryPoint.Visible = highlightedSomething &&
-                this.relevantDefinition.RelevantManipulation.Type == ElementManipulationType.MoveEdge;
-
-            this.mnuRemoveBoundaryPoint.Visible = highlightedSomething &&
-                this.relevantDefinition.RelevantManipulation.Type == ElementManipulationType.MoveBoundary;
-
-            this.mnuRemoveElement.Visible = highlightedSomething;
-            this.mnuAddElement.Visible = this.mnuToggleEditMode.Checked && this.relevantDefinition == null;
-        }
-
-        /// <summary>
-        /// Handles setting the menu open variable to false when the form loses focus.
-        /// </summary>
-        private void MainForm_Deactivate(object sender, EventArgs e)
-        {
-            // Deactivating the form also closes the menu.
-            this.menuOpen = false;
-        }
-
-        /// <summary>
-        /// Exits the application.
-        /// </summary>
-        private void mnuExit_Click(object sender, EventArgs e)
-        {
-            Application.Exit();
-        }
-
-        #endregion Settings
-
-        #region Rendering
-
-        /// <summary>
-        /// Paints the keyboard on the screen.
-        /// </summary>
-        protected override void OnPaint(PaintEventArgs e)
-        {
-            e.Graphics.Clear(GlobalSettings.CurrentStyle.BackgroundColor);
-
-            if (GlobalSettings.CurrentDefinition == null || !this.backBrushes.Any())
-                return;
-
-            // Fill the appropriate back brush.
-            e.Graphics.FillRectangle(
-                this.backBrushes[KeyboardState.ShiftDown][KeyboardState.CapsActive],
-                new Rectangle(0, 0, GlobalSettings.CurrentDefinition.Width, GlobalSettings.CurrentDefinition.Height));
-
-            // Render all keys.
-            KeyboardState.CheckKeyHolds(GlobalSettings.Settings.PressHold);
-            var kbKeys = KeyboardState.PressedKeys;
-            var mouseKeys = MouseState.PressedKeys.Select(k => (int)k).ToList();
-            MouseState.CheckKeyHolds(GlobalSettings.Settings.PressHold);
-            MouseState.CheckScrollAndMovement();
-            var scrollCounts = MouseState.ScrollCounts;
-            var allDefs = GlobalSettings.CurrentDefinition.Elements;
-            foreach (var def in allDefs)
-            {
-                this.Render(e.Graphics, def, allDefs, kbKeys, mouseKeys, scrollCounts, false);
-            }
-
-            // Draw the element being manipulated
-            if (this.currentlyManipulating == null)
-            {
-                if (this.highlightedDefinition != this.selectedDefinition)
-                    // Draw highlighted only if it is not also selected.
-                    this.highlightedDefinition?.RenderHighlight(e.Graphics);
-
-                if (this.selectedDefinition != null)
-                {
-                    this.Render(e.Graphics, this.selectedDefinition, allDefs, kbKeys, mouseKeys, scrollCounts, true);
-                    this.selectedDefinition.RenderSelected(e.Graphics);
-                }
-            }
-            else
-            {
-                this.currentlyManipulating.Value.definition.RenderEditing(e.Graphics);
-            }
-
-            base.OnPaint(e);
-        }
-
-        /// <summary>
-        /// Renders a single element definition.
-        /// </summary>
-        /// <param name="g">The GDI+ surface to render on.</param>
-        /// <param name="def">The element definition to render.</param>
-        /// <param name="allDefs">The list of all element definition.</param>
-        /// <param name="kbKeys">The list of keyboard keys that are pressed.</param>
-        /// <param name="mouseKeys">The list of mouse keys that are pressed.</param>
-        /// <param name="scrollCounts">The list of scroll counts.</param>
-        /// <param name="scrollCounts">If <c>true</c>, the key will always render, regardless of whether it is
-        /// different from the background.</param>
-        private void Render(
-            Graphics g,
-            ElementDefinition def,
-            List<ElementDefinition> allDefs,
-            IReadOnlyList<int> kbKeys,
-            List<int> mouseKeys,
-            IReadOnlyList<int> scrollCounts,
-            bool alwaysRender)
-        {
-            if (def is KeyboardKeyDefinition kkDef)
-            {
-                var pressed = true;
-                if (!kkDef.KeyCodes.Any() || !kkDef.KeyCodes.All(kbKeys.Contains)) pressed = false;
-
-                if (kkDef.KeyCodes.Count == 1
-                    && allDefs.OfType<KeyboardKeyDefinition>()
-                        .Any(d => d.KeyCodes.Count > 1
-                        && d.KeyCodes.All(kbKeys.Contains)
-                        && d.KeyCodes.ContainsAll(kkDef.KeyCodes))) pressed = false;
-
-                if (!pressed && !alwaysRender) return;
-
-                kkDef.Render(g, pressed, KeyboardState.ShiftDown, KeyboardState.CapsActive);
-            }
-            if (def is MouseKeyDefinition mkDef)
-            {
-                var pressed = mouseKeys.Contains(mkDef.KeyCodes.Single());
-                if (pressed || alwaysRender)
-                    mkDef.Render(g, pressed, KeyboardState.ShiftDown, KeyboardState.CapsActive);
-            }
-            if (def is MouseScrollDefinition msDef)
-            {
-                var scrollCount = scrollCounts[msDef.KeyCodes.Single()];
-                if (scrollCount > 0 || alwaysRender) msDef.Render(g, scrollCount);
-            }
-            if (def is MouseSpeedIndicatorDefinition)
-            {
-                ((MouseSpeedIndicatorDefinition)def).Render(g, MouseState.AverageSpeed);
-            }
-        }
-
-        /// <summary>
-        /// Forces an update if any of the key or mouse states have changed.
-        /// </summary>
-        private void UpdateTimer_Tick(object sender, EventArgs e)
-        {
-            if (KeyboardState.Updated || MouseState.Updated)
-                this.Refresh();
-        }
-
-        /// <summary>
-        /// Periodically checks that no keys got stuck.
-        /// </summary>
-        private void KeyCheckTimer_Tick(object sender, EventArgs e)
-        {
-            MouseState.CheckKeys(GlobalSettings.Settings.PressHold);
-            KeyboardState.CheckKeys(GlobalSettings.Settings.PressHold);
-        }
-
-        #endregion Rendering
-
-        /// <summary>
-        /// Crashes NohBoard, in order to generate a crash log.
-        /// This seems strange, but can be an easy way for someone to serialize all their settings into a single file
-        /// to be sent for support reasons.
-        /// </summary>
-        private void mnuGenerateLog_Click(object sender, EventArgs e)
-        {
-            if (MessageBox.Show("This will crash NohBoard in order to generate a log, are you sure you want to do this?", "Generate crash log", MessageBoxButtons.OKCancel) == DialogResult.OK)
-            {
-                throw new Exception("A crash log was requested.");
-            }
-        }
-    }
+	using Extra;
+	using Hooking;
+	using Hooking.Interop;
+	using Keyboard;
+	using Keyboard.ElementDefinitions;
+	using System;
+	using System.Collections.Generic;
+	using System.Diagnostics;
+	using System.Drawing;
+	using System.Drawing.Text;
+	using System.Linq;
+	using System.Net.Http;
+	using System.Runtime.Serialization.Json;
+	using System.Text;
+	using System.Threading.Tasks;
+	using System.Windows.Forms;
+	using System.Xml;
+	using ThoNohT.NohBoard.Keyboard.Styles;
+	using Version = NohBoard.Version;
+
+	/// <summary>
+	/// The main form.
+	/// </summary>
+	public partial class MainForm : Form
+	{
+		#region Fields
+
+		/// <summary>
+		/// The back-brushes used for efficient drawing.
+		/// </summary>
+		private readonly Dictionary<bool, Dictionary<bool, Brush>> backBrushes =
+			new Dictionary<bool, Dictionary<bool, Brush>>();
+
+		/// <summary>
+		/// The element currently under the cursor.
+		/// </summary>
+		private ElementDefinition elementUnderCursor = null;
+
+		/// <summary>
+		/// The latest version, if it was retrieved from the update site.
+		/// </summary>
+		private VersionInfo latestVersion = null;
+
+		#endregion Fields
+
+		#region Constructors
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MainForm" /> class.
+		/// </summary>
+		public MainForm()
+		{
+			this.InitializeComponent();
+			this.SetStyle(ControlStyles.ResizeRedraw, true);
+		}
+
+		#endregion Constructors
+
+		#region Version check
+
+		/// <summary>
+		/// Attempts to retrieve the latest version from the update site.
+		/// </summary>
+		public Task GetLatestVersion()
+		{
+			return new Task(
+				() =>
+				{
+					var updateUrl =
+						"https://gist.githubusercontent.com/ThoNohT/3181561f8148fb6b865f88714e975154/raw/nohboard_version.json";
+
+					VersionInfo downloadVersionInfo(string url)
+					{
+						var serializer = new DataContractJsonSerializer(typeof(VersionInfo));
+						using(var client = new HttpClient())
+						using(var reader = JsonReaderWriterFactory.CreateJsonReader(
+							client.GetStreamAsync(updateUrl).Result,
+							Encoding.UTF8,
+							XmlDictionaryReaderQuotas.Max,
+							dictionaryReader => { }))
+						{
+							return (VersionInfo)serializer.ReadObject(reader);
+						}
+					}
+
+					var versionInfo = downloadVersionInfo(updateUrl);
+
+					if((versionInfo.Major > Version.Major) ||
+						(versionInfo.Major == Version.Major && versionInfo.Minor > Version.Minor) ||
+						(versionInfo.Major == Version.Major && versionInfo.Minor == Version.Minor
+						 && versionInfo.Patch > Version.Patch))
+					{
+						this.latestVersion = versionInfo;
+					}
+				});
+		}
+
+		#endregion Version check
+
+		#region Keyboard loading and saving
+
+		/// <summary>
+		/// Loads the keyboard currently defined in the settings.
+		/// </summary>
+		/// <returns>The list of fonts that are not present on this system and might be downloaded for this keyboard.
+		/// </returns>
+		private List<SerializableFont> LoadKeyboard()
+		{
+			if(GlobalSettings.CurrentDefinition == null)
+			{
+				HookManager.DisableKeyboardHook();
+				HookManager.DisableMouseHook();
+
+				return new List<SerializableFont>();
+			}
+			// Enable the mouse hook only if there are mouse keys on the screen.
+			if(GlobalSettings.CurrentDefinition.Elements.Any(x => !(x is KeyboardKeyDefinition)))
+				HookManager.EnableMouseHook();
+			else
+				HookManager.DisableMouseHook();
+
+			// Enable the keyboard hook only if there are keyboard keys on the screen.
+			if(GlobalSettings.CurrentDefinition.Elements.Any(x => x is KeyboardKeyDefinition))
+				HookManager.EnableKeyboardHook();
+			else
+				HookManager.DisableKeyboardHook();
+
+			//Prompt to download any fonts we don't have yet.
+			var missingFonts = this.CheckMissingFonts();
+
+			GlobalSettings.Settings.InitUndoHistory();
+
+			// Reset all edit mode related fields, as we should be no longer in edit mode.
+			if(this.mnuToggleEditMode.Checked)
+			{
+				this.mnuToggleEditMode.Checked = false;
+				this.mnuToggleEditMode_Click(null, null);
+			}
+
+			this.currentlyManipulating = null;
+			this.highlightedDefinition = null;
+			this.selectedDefinition = null;
+
+			this.ClientSize = new Size(GlobalSettings.CurrentDefinition.Width, GlobalSettings.CurrentDefinition.Height);
+
+			this.ResetBackBrushes();
+
+			return missingFonts;
+		}
+
+		/// <summary>
+		/// Checks if there are any fonts that are not on the system, and do have a download link in them. If this is
+		/// the case, then those fonts are returned.
+		/// </summary>
+		/// <returns>The list of fonts that are not present and might be downloaded. Missing fonts without a download
+		/// link are also returned.</returns>
+		private List<SerializableFont> CheckMissingFonts()
+		{
+			var style = GlobalSettings.CurrentStyle;
+			var usedFonts = style.ElementStyles.Values.OfType<KeyStyle>()
+				.SelectMany(s => new[] { s.Loose?.Font, s.Pressed?.Font })
+				.Union(new[] { style.DefaultKeyStyle?.Loose?.Font, style.DefaultKeyStyle?.Pressed?.Font })
+				.Where(f => f != null).ToList();
+
+			var installedFonts = new InstalledFontCollection();
+			var installedFontFamilyNames = new HashSet<string>(installedFonts.Families.Select(f => f.Name));
+			var notInstalledUsedFonts = usedFonts.Where(f => !installedFontFamilyNames.Contains(f.FontFamily)).ToList();
+
+			foreach(var font in notInstalledUsedFonts)
+			{
+				// For now, update the used family to the default. Next time they could have downloaded the font.
+				font.AlternateFontFamily = SystemFonts.DefaultFont.FontFamily.Name;
+			}
+
+			if(!notInstalledUsedFonts.Any()) return new List<SerializableFont>();
+
+			return notInstalledUsedFonts.OrderBy(f => f.DownloadUrl == null).Distinct(new SerializableFont.FamilyComparer()).ToList();
+		}
+
+		/// <summary>
+		/// Redraws the back-brushes. These back-brushes are drawn for all possible states of the keys when none of them
+		/// are pressed. This prevents having to render each of these keys every time. However, every time anything
+		/// about the definition or style changes, the back-brushes have to be re-rendered.
+		/// </summary>
+		private void ResetBackBrushes()
+		{
+			GlobalSettings.StyleDependencyCounter++;
+
+			foreach(var brush in this.backBrushes)
+			{
+				foreach(var b in brush.Value)
+					b.Value.Dispose();
+
+				brush.Value.Clear();
+			}
+			this.backBrushes.Clear();
+
+			// Fill the back-brushes.
+			foreach(var shift in new[] { false, true })
+			{
+				this.backBrushes.Add(shift, new Dictionary<bool, Brush>());
+
+				foreach(var caps in new[] { false, true })
+				{
+					var bmp = new Bitmap(
+						GlobalSettings.CurrentDefinition.Width,
+						GlobalSettings.CurrentDefinition.Height);
+					var g = Graphics.FromImage(bmp);
+
+					// Render the background image if set.
+					var cs = GlobalSettings.CurrentStyle;
+					if(cs.BackgroundImageFileName != null && FileHelper.StyleImageExists(cs.BackgroundImageFileName))
+					{
+						g.DrawImage(ImageCache.Get(cs.BackgroundImageFileName), this.ClientRectangle);
+					}
+
+					// Render the individual keys.
+					foreach(var def in GlobalSettings.CurrentDefinition.Elements)
+					{
+						if(def is KeyboardKeyDefinition) ((KeyboardKeyDefinition)def).Render(g, false, shift, caps);
+
+						if(def is MouseKeyDefinition) ((MouseKeyDefinition)def).Render(g, false, shift, caps);
+
+						if(def is MouseScrollDefinition) ((MouseScrollDefinition)def).Render(g, 0);
+
+						// No need to render mouse speed indicators in backbrush.
+					}
+
+					this.backBrushes[shift].Add(caps, new TextureBrush(bmp));
+				}
+			}
+
+			this.Refresh();
+		}
+
+		/// <summary>
+		/// Opens the load keyboard form.
+		/// </summary>
+		private void mnuLoadKeyboard_Click(object sender, EventArgs e)
+		{
+			if(GlobalSettings.UnsavedDefinitionChanges || GlobalSettings.UnsavedStyleChanges)
+			{
+				var result = MessageBox.Show(
+					"You have unsaved changes. Loading a new keyboard will undo them. Are you sure you want to load a new keyboard?",
+					"Discard changes",
+					MessageBoxButtons.OKCancel,
+					MessageBoxIcon.Warning);
+
+				if(result != DialogResult.OK) return;
+			}
+
+			this.menuOpen = false;
+
+			using(var manageForm = new LoadKeyboardForm())
+			{
+				manageForm.DefinitionChanged += (kbDef, kbStyle, globalStyle) =>
+				{
+					var backupDef = GlobalSettings.CurrentDefinition;
+					var backupStyle = GlobalSettings.CurrentStyle;
+
+					var backupCat = GlobalSettings.Settings.LoadedCategory;
+					var backupKb = GlobalSettings.Settings.LoadedKeyboard;
+					var backupKbStyle = GlobalSettings.Settings.LoadedStyle;
+					var backupkbGlobalStyle = GlobalSettings.Settings.LoadedGlobalStyle;
+
+					// Don't worry about undo history, it will be initialized alter in LoadKeyboard.
+					GlobalSettings.Settings.UpdateDefinition(kbDef, false);
+					GlobalSettings.Settings.UpdateStyle(kbStyle ?? new KeyboardStyle(), false);
+
+					GlobalSettings.Settings.LoadedCategory = kbDef.Category;
+					GlobalSettings.Settings.LoadedKeyboard = kbDef.Name;
+					GlobalSettings.Settings.LoadedStyle = kbStyle?.Name;
+					GlobalSettings.Settings.LoadedGlobalStyle = globalStyle;
+
+					try
+					{
+						var missingFonts = this.LoadKeyboard();
+						manageForm.ToggleFontsPanel(missingFonts);
+					}
+					catch(Exception ex)
+					{
+						GlobalSettings.Settings.UpdateDefinition(backupDef, false);
+						GlobalSettings.Settings.UpdateStyle(backupStyle, false);
+
+						GlobalSettings.Settings.LoadedCategory = backupCat;
+						GlobalSettings.Settings.LoadedKeyboard = backupKb;
+						GlobalSettings.Settings.LoadedStyle = backupKbStyle;
+						GlobalSettings.Settings.LoadedGlobalStyle = backupkbGlobalStyle;
+
+						this.LoadKeyboard();
+
+						MessageBox.Show(ex.Message + Environment.NewLine + "Reverted keyboard change.");
+					}
+				};
+
+				manageForm.ShowDialog(this);
+			}
+		}
+
+		/// <summary>
+		/// Saves the current definition under its default name.
+		/// </summary>
+		private void mnuSaveDefinitionAsName_Click(object sender, EventArgs e)
+		{
+			this.menuOpen = false;
+
+			GlobalSettings.CurrentDefinition.Save();
+			GlobalSettings.Settings.LoadedCategory = GlobalSettings.CurrentDefinition.Category;
+			GlobalSettings.Settings.LoadedKeyboard = GlobalSettings.CurrentDefinition.Name;
+		}
+
+		/// <summary>
+		/// Opens a form the save the current definition under a custom name.
+		/// </summary>
+		private void mnuSaveDefinitionAs_Click(object sender, EventArgs e)
+		{
+			this.menuOpen = false;
+
+			using(var saveForm = new SaveKeyboardAsForm())
+			{
+				saveForm.ShowDialog(this);
+			}
+		}
+
+		#endregion Keyboard loading and saving
+
+		#region Settings
+
+		/// <summary>
+		/// Handles the loading of the form, all settings are read, hooks are created and the keyboard is initialized.
+		/// </summary>
+		private void MainForm_Load(object sender, EventArgs e)
+		{
+			// Load the settings
+			if(!GlobalSettings.Load())
+			{
+				MessageBox.Show(
+					this,
+					$"Failed to load the settings: {GlobalSettings.Errors}",
+					"Failed to load settings");
+			}
+
+			this.Location = new Point(GlobalSettings.Settings.X, GlobalSettings.Settings.Y);
+			var title = GlobalSettings.Settings.WindowTitle;
+
+			this.Text = string.IsNullOrWhiteSpace(title) ? $"NohBoard {Version.Get}" : title;
+
+			this.GetLatestVersion().Start();
+
+			// Load a definition if possible.
+			if(GlobalSettings.Settings.LoadedKeyboard != null && GlobalSettings.Settings.LoadedCategory != null)
+			{
+				try
+				{
+					GlobalSettings.Settings.UpdateDefinition(KeyboardDefinition
+						.Load(GlobalSettings.Settings.LoadedCategory, GlobalSettings.Settings.LoadedKeyboard), false);
+				}
+				catch(Exception ex)
+				{
+					MessageBox.Show(
+						"There was an error loading the saved keyboard definition file:" +
+						$"{Environment.NewLine}{ex.Message}");
+					GlobalSettings.Settings.LoadedCategory = null;
+					GlobalSettings.Settings.LoadedKeyboard = null;
+				}
+			}
+
+			// Load a style if possible.
+			if(GlobalSettings.CurrentDefinition != null && GlobalSettings.Settings.LoadedStyle != null)
+			{
+				try
+				{
+					GlobalSettings.Settings.UpdateStyle(KeyboardStyle.Load(
+						GlobalSettings.Settings.LoadedStyle,
+						GlobalSettings.Settings.LoadedGlobalStyle), false);
+					this.LoadKeyboard();
+					this.ResetBackBrushes();
+				}
+				catch
+				{
+					GlobalSettings.Settings.LoadedStyle = null;
+					MessageBox.Show(
+						$"Failed to load style {GlobalSettings.Settings.LoadedStyle}, loading default style.",
+						"Error loading style.");
+				}
+
+				// Enable the mouse hook only if there are mouse keys on the screen.
+				if(GlobalSettings.CurrentDefinition.Elements.Any(x => !(x is KeyboardKeyDefinition)))
+					HookManager.EnableMouseHook();
+
+				// Enable the keyboard hook only if there are keyboard keys on the screen.
+				if(GlobalSettings.CurrentDefinition.Elements.Any(x => x is KeyboardKeyDefinition))
+					HookManager.EnableKeyboardHook();
+			}
+
+			this.UpdateTimer.Interval = GlobalSettings.Settings.UpdateInterval;
+			this.UpdateTimer.Enabled = true;
+			this.KeyCheckTimer.Enabled = true;
+
+			this.Activate();
+			this.ApplySettings();
+		}
+
+		/// <summary>
+		/// Handles the moving of the form. Stores the current position for future use.
+		/// </summary>
+		private void MainForm_Move(object sender, EventArgs e)
+		{
+			if(GlobalSettings.Settings != null && this.WindowState == FormWindowState.Normal)
+			{
+				GlobalSettings.Settings.X = this.Location.X;
+				GlobalSettings.Settings.Y = this.Location.Y;
+			}
+		}
+
+		/// <summary>
+		/// Handles the closing of the form. Hooks are disabled and the settings are saved before closing.
+		/// </summary>
+		private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
+		{
+			if(GlobalSettings.UnsavedDefinitionChanges || GlobalSettings.UnsavedStyleChanges && !CrashHandler.Crashed)
+			{
+				var result = MessageBox.Show(
+					"You have unsaved changes. If you exit now you will lose them. Are you sure you want to exit?",
+					"Discard changes",
+					MessageBoxButtons.OKCancel,
+					MessageBoxIcon.Warning);
+
+				if(result != DialogResult.OK)
+				{
+					e.Cancel = true;
+					return;
+				}
+			}
+
+			HookManager.DisableMouseHook();
+			HookManager.DisableKeyboardHook();
+
+			GlobalSettings.Save();
+		}
+
+		/// <summary>
+		/// Applies the currently stored settings.
+		/// </summary>
+		private void ApplySettings()
+		{
+			HookManager.TrapKeyboard = GlobalSettings.Settings.TrapKeyboard;
+			HookManager.TrapMouse = GlobalSettings.Settings.TrapMouse;
+			HookManager.TrapToggleKeyCode = GlobalSettings.Settings.TrapToggleKeyCode;
+			HookManager.ScrollHold = GlobalSettings.Settings.ScrollHold;
+			HookManager.PressHold = GlobalSettings.Settings.PressHold;
+
+			var title = GlobalSettings.Settings.WindowTitle;
+			this.Text = string.IsNullOrWhiteSpace(title) ? $"NohBoard {Version.Get}" : title;
+
+			this.LoadKeyboard();
+		}
+
+		/// <summary>
+		/// Opens the settings form.
+		/// </summary>
+		private void mnuSettings_Click(object sender, EventArgs e)
+		{
+			this.menuOpen = false;
+
+			using(var settingsForm = new SettingsForm())
+			{
+				var result = settingsForm.ShowDialog(this);
+
+				if(result == DialogResult.Cancel)
+					return;
+
+				// Re-initialize with the new settings.
+				this.ApplySettings();
+			}
+		}
+
+		/// <summary>
+		/// Populates the main menu. Elements are visible based on which definitions and styles are loaded, and whether
+		/// actions on a specifically pointed element are possible.
+		/// </summary>
+		private void MainMenu_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+		{
+			this.menuOpen = true;
+
+			this.mnuSaveDefinition.Enabled = GlobalSettings.CurrentDefinition != null;
+			if(GlobalSettings.CurrentDefinition != null)
+			{
+				this.mnuSaveDefinitionAsName.Text =
+					$"Save &To '{GlobalSettings.CurrentDefinition.Category}/{GlobalSettings.CurrentDefinition.Name}'";
+
+				var mousePos = this.PointToClient(Cursor.Position);
+				this.elementUnderCursor =
+					GlobalSettings.CurrentDefinition.Elements.FirstOrDefault(x => x.Inside(mousePos));
+
+				// Set the highlighted definition only if we're in edit mode, and there is not an already selected definition.
+				if(this.mnuToggleEditMode.Checked && this.selectedDefinition == null)
+				{
+					this.highlightedDefinition = this.elementUnderCursor;
+					this.highlightedDefinition?.StartManipulating(mousePos, false);
+				}
+
+				var relevantElement = this.selectedDefinition ?? this.elementUnderCursor;
+				this.mnuEditElementStyle.Enabled = relevantElement != null;
+				this.mnuElementProperties.Enabled = relevantElement != null;
+			}
+
+			// Only allow editing of properties/styles in edit mode.
+			this.mnuKeyboardProperties.Visible = this.mnuToggleEditMode.Checked;
+			this.mnuUpdateTextPosition.Visible = this.mnuToggleEditMode.Checked;
+			this.mnuElementProperties.Visible = this.mnuToggleEditMode.Checked;
+			this.mnuEditKeyboardStyle.Visible = this.mnuToggleEditMode.Checked;
+			this.mnuEditElementStyle.Visible = this.mnuToggleEditMode.Checked;
+			this.MainMenuSep1.Visible = this.mnuToggleEditMode.Checked;
+
+			this.mnuSaveStyleToName.Text = $"Save &To '{GlobalSettings.CurrentStyle.Name}'";
+			this.mnuSaveStyleToName.Visible = !GlobalSettings.Settings.LoadedGlobalStyle;
+			this.mnuSaveToGlobalStyleName.Text = $"Save To &Global '{GlobalSettings.CurrentStyle.Name}'";
+			this.mnuSaveToGlobalStyleName.Enabled = GlobalSettings.CurrentStyle.IsGlobal;
+			this.mnuSaveToGlobalStyleName.Visible = GlobalSettings.Settings.LoadedGlobalStyle;
+
+			this.mnuToggleEditMode.Enabled = GlobalSettings.CurrentDefinition != null;
+
+			if(this.latestVersion != null && !this.mnuUpdate.Visible)
+			{
+				this.mnuUpdate.Text = $"New version available: {this.latestVersion.Format()}.";
+				this.mnuUpdate.Visible = true;
+				this.mnuUpdate.Click += (s, ea) => { Process.Start(new ProcessStartInfo { FileName = "https://github.com/ThoNohT/NohBoard/releases", UseShellExecute = true }); };
+			}
+
+			this.mnuMoveElement.Visible = this.relevantDefinition != null;
+
+			var highlightedSomething = this.mnuToggleEditMode.Checked && this.relevantDefinition != null;
+
+			// Edit mode related menu items.
+			this.mnuAddBoundaryPoint.Visible = highlightedSomething &&
+				this.relevantDefinition.RelevantManipulation.Type == ElementManipulationType.MoveEdge;
+
+			this.mnuRemoveBoundaryPoint.Visible = highlightedSomething &&
+				this.relevantDefinition.RelevantManipulation.Type == ElementManipulationType.MoveBoundary;
+
+			this.mnuRemoveElement.Visible = highlightedSomething;
+			this.mnuAddElement.Visible = this.mnuToggleEditMode.Checked && this.relevantDefinition == null;
+		}
+
+		/// <summary>
+		/// Handles setting the menu open variable to false when the form loses focus.
+		/// </summary>
+		private void MainForm_Deactivate(object sender, EventArgs e)
+		{
+			// Deactivating the form also closes the menu.
+			this.menuOpen = false;
+		}
+
+		/// <summary>
+		/// Exits the application.
+		/// </summary>
+		private void mnuExit_Click(object sender, EventArgs e)
+		{
+			Application.Exit();
+		}
+
+		#endregion Settings
+
+		#region Rendering
+
+		/// <summary>
+		/// Paints the keyboard on the screen.
+		/// </summary>
+		protected override void OnPaint(PaintEventArgs e)
+		{
+			e.Graphics.Clear(GlobalSettings.CurrentStyle.BackgroundColor);
+
+			if(GlobalSettings.CurrentDefinition == null || !this.backBrushes.Any())
+				return;
+
+			// Fill the appropriate back brush.
+			e.Graphics.FillRectangle(
+				this.backBrushes[KeyboardState.ShiftDown][KeyboardState.CapsActive],
+				new Rectangle(0, 0, GlobalSettings.CurrentDefinition.Width, GlobalSettings.CurrentDefinition.Height));
+
+			// Render all keys.
+			KeyboardState.CheckKeyHolds(GlobalSettings.Settings.PressHold);
+			var kbKeys = KeyboardState.PressedKeys;
+			var mouseKeys = MouseState.PressedKeys.Select(k => (int)k).ToList();
+			MouseState.CheckKeyHolds(GlobalSettings.Settings.PressHold);
+			MouseState.CheckScrollAndMovement();
+			var scrollCounts = MouseState.ScrollCounts;
+			var allDefs = GlobalSettings.CurrentDefinition.Elements;
+			foreach(var def in allDefs)
+			{
+				this.Render(e.Graphics, def, allDefs, kbKeys, mouseKeys, scrollCounts, false);
+			}
+
+			// Draw the element being manipulated
+			if(this.currentlyManipulating == null)
+			{
+				if(this.highlightedDefinition != this.selectedDefinition)
+					// Draw highlighted only if it is not also selected.
+					this.highlightedDefinition?.RenderHighlight(e.Graphics);
+
+				if(this.selectedDefinition != null)
+				{
+					this.Render(e.Graphics, this.selectedDefinition, allDefs, kbKeys, mouseKeys, scrollCounts, true);
+					this.selectedDefinition.RenderSelected(e.Graphics);
+				}
+			}
+			else
+			{
+				this.currentlyManipulating.Value.definition.RenderEditing(e.Graphics);
+			}
+
+			base.OnPaint(e);
+		}
+
+		/// <summary>
+		/// Renders a single element definition.
+		/// </summary>
+		/// <param name="g">The GDI+ surface to render on.</param>
+		/// <param name="def">The element definition to render.</param>
+		/// <param name="allDefs">The list of all element definition.</param>
+		/// <param name="kbKeys">The list of keyboard keys that are pressed.</param>
+		/// <param name="mouseKeys">The list of mouse keys that are pressed.</param>
+		/// <param name="scrollCounts">The list of scroll counts.</param>
+		/// <param name="scrollCounts">If <c>true</c>, the key will always render, regardless of whether it is
+		/// different from the background.</param>
+		private void Render(
+			Graphics g,
+			ElementDefinition def,
+			List<ElementDefinition> allDefs,
+			IReadOnlyList<int> kbKeys,
+			List<int> mouseKeys,
+			IReadOnlyList<int> scrollCounts,
+			bool alwaysRender)
+		{
+			if(def is KeyboardKeyDefinition kkDef)
+			{
+				bool pressed = keyPressed(kkDef, kbKeys, allDefs);
+
+				if(kkDef.KeyCodes.Count == 1
+					&& allDefs.OfType<KeyboardKeyDefinition>()
+						.Any(d => d.KeyCodes.Count > 1
+						&& d.KeyCodes.All(kbKeys.Contains)
+						&& d.KeyCodes.ContainsAll(kkDef.KeyCodes))) pressed = false;
+
+				if(!pressed && !alwaysRender) return;
+
+				kkDef.Render(g, pressed, KeyboardState.ShiftDown, KeyboardState.CapsActive);
+			}
+			else if(def is MouseKeyDefinition mkDef)
+			{
+				var pressed = mouseKeys.Contains(mkDef.KeyCodes.Single());
+				if(pressed || alwaysRender)
+					mkDef.Render(g, pressed, KeyboardState.ShiftDown, KeyboardState.CapsActive);
+			}
+			else if(def is MouseScrollDefinition msDef)
+			{
+				var scrollCount = scrollCounts[msDef.KeyCodes.Single()];
+				if(scrollCount > 0 || alwaysRender) msDef.Render(g, scrollCount);
+			}
+			else if(def is MouseSpeedIndicatorDefinition)
+			{
+				((MouseSpeedIndicatorDefinition)def).Render(g, MouseState.AverageSpeed);
+			}
+		}
+
+		private bool keyPressed(KeyboardKeyDefinition keyboardKeyDef, IReadOnlyList<int> pressedKeyCodes, List<ElementDefinition> allDefs)
+		{
+			bool hasKeyCodes = keyboardKeyDef.KeyCodes.Any();
+			if(!hasKeyCodes)
+			{
+				return false;
+			}
+			else
+			{
+				if(keyboardKeyDef.KeyCodesOrMode)
+				{
+					return keyboardKeyDef.KeyCodes.Any(pressedKeyCodes.Contains);
+				}
+				else
+				{
+					return keyboardKeyDef.KeyCodes.All(pressedKeyCodes.Contains);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Forces an update if any of the key or mouse states have changed.
+		/// </summary>
+		private void UpdateTimer_Tick(object sender, EventArgs e)
+		{
+			if(KeyboardState.Updated || MouseState.Updated)
+				this.Refresh();
+		}
+
+		/// <summary>
+		/// Periodically checks that no keys got stuck.
+		/// </summary>
+		private void KeyCheckTimer_Tick(object sender, EventArgs e)
+		{
+			MouseState.CheckKeys(GlobalSettings.Settings.PressHold);
+			KeyboardState.CheckKeys(GlobalSettings.Settings.PressHold);
+		}
+
+		#endregion Rendering
+
+		/// <summary>
+		/// Crashes NohBoard, in order to generate a crash log.
+		/// This seems strange, but can be an easy way for someone to serialize all their settings into a single file
+		/// to be sent for support reasons.
+		/// </summary>
+		private void mnuGenerateLog_Click(object sender, EventArgs e)
+		{
+			if(MessageBox.Show("This will crash NohBoard in order to generate a log, are you sure you want to do this?", "Generate crash log", MessageBoxButtons.OKCancel) == DialogResult.OK)
+			{
+				throw new Exception("A crash log was requested.");
+			}
+		}
+	}
 }

--- a/NohBoard/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.Designer.cs
+++ b/NohBoard/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.Designer.cs
@@ -17,387 +17,402 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace ThoNohT.NohBoard.Forms.Properties
 {
-    partial class KeyboardKeyPropertiesForm
-    {
-        /// <summary>
-        /// Required designer variable.
-        /// </summary>
-        private System.ComponentModel.IContainer components = null;
+	partial class KeyboardKeyPropertiesForm
+	{
+		/// <summary>
+		/// Required designer variable.
+		/// </summary>
+		private System.ComponentModel.IContainer components = null;
 
-        /// <summary>
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing && (this.components != null))
-            {
-                this.components.Dispose();
-            }
-            base.Dispose(disposing);
-        }
+		/// <summary>
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing)
+		{
+			if(disposing && (this.components != null))
+			{
+				this.components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
 
-        #region Windows Form Designer generated code
+		#region Windows Form Designer generated code
 
-        /// <summary>
-        /// Required method for Designer support - do not modify
-        /// the contents of this method with the code editor.
-        /// </summary>
-        private void InitializeComponent()
-        {
-            this.btnBoundaryDown = new System.Windows.Forms.Button();
-            this.btnBoundaryUp = new System.Windows.Forms.Button();
-            this.btnRemoveBoundary = new System.Windows.Forms.Button();
-            this.btnAddBoundary = new System.Windows.Forms.Button();
-            this.CancelButton2 = new System.Windows.Forms.Button();
-            this.AcceptButton2 = new System.Windows.Forms.Button();
-            this.lblBoundaries = new System.Windows.Forms.Label();
-            this.lstBoundaries = new System.Windows.Forms.ListBox();
-            this.lblText = new System.Windows.Forms.Label();
-            this.txtText = new System.Windows.Forms.TextBox();
-            this.lblTextPosition = new System.Windows.Forms.Label();
-            this.lblShiftText = new System.Windows.Forms.Label();
-            this.txtShiftText = new System.Windows.Forms.TextBox();
-            this.lstKeyCodes = new System.Windows.Forms.ListBox();
-            this.btnRemoveKeyCode = new System.Windows.Forms.Button();
-            this.btnAddKeyCode = new System.Windows.Forms.Button();
-            this.udKeyCode = new System.Windows.Forms.NumericUpDown();
-            this.lblKeyCodes = new System.Windows.Forms.Label();
-            this.chkChangeOnCaps = new System.Windows.Forms.CheckBox();
-            this.btnUpdateBoundary = new System.Windows.Forms.Button();
-            this.btnCenterText = new System.Windows.Forms.Button();
-            this.btnRectangle = new System.Windows.Forms.Button();
-            this.btnDetectKeyCode = new System.Windows.Forms.Button();
-            this.txtBoundaries = new ThoNohT.NohBoard.Controls.VectorTextBox();
-            this.txtTextPosition = new ThoNohT.NohBoard.Controls.VectorTextBox();
-            ((System.ComponentModel.ISupportInitialize)(this.udKeyCode)).BeginInit();
-            this.SuspendLayout();
-            // 
-            // btnBoundaryDown
-            // 
-            this.btnBoundaryDown.Location = new System.Drawing.Point(4, 232);
-            this.btnBoundaryDown.Name = "btnBoundaryDown";
-            this.btnBoundaryDown.Size = new System.Drawing.Size(75, 23);
-            this.btnBoundaryDown.TabIndex = 10;
-            this.btnBoundaryDown.Text = "Down";
-            this.btnBoundaryDown.UseVisualStyleBackColor = true;
-            this.btnBoundaryDown.Click += new System.EventHandler(this.btnBoundaryDown_Click);
-            // 
-            // btnBoundaryUp
-            // 
-            this.btnBoundaryUp.Location = new System.Drawing.Point(4, 203);
-            this.btnBoundaryUp.Name = "btnBoundaryUp";
-            this.btnBoundaryUp.Size = new System.Drawing.Size(75, 23);
-            this.btnBoundaryUp.TabIndex = 9;
-            this.btnBoundaryUp.Text = "Up";
-            this.btnBoundaryUp.UseVisualStyleBackColor = true;
-            this.btnBoundaryUp.Click += new System.EventHandler(this.btnBoundaryUp_Click);
-            // 
-            // btnRemoveBoundary
-            // 
-            this.btnRemoveBoundary.Location = new System.Drawing.Point(4, 174);
-            this.btnRemoveBoundary.Name = "btnRemoveBoundary";
-            this.btnRemoveBoundary.Size = new System.Drawing.Size(75, 23);
-            this.btnRemoveBoundary.TabIndex = 8;
-            this.btnRemoveBoundary.Text = "Remove";
-            this.btnRemoveBoundary.UseVisualStyleBackColor = true;
-            this.btnRemoveBoundary.Click += new System.EventHandler(this.btnRemoveBoundary_Click);
-            // 
-            // btnAddBoundary
-            // 
-            this.btnAddBoundary.Location = new System.Drawing.Point(4, 116);
-            this.btnAddBoundary.Name = "btnAddBoundary";
-            this.btnAddBoundary.Size = new System.Drawing.Size(75, 23);
-            this.btnAddBoundary.TabIndex = 6;
-            this.btnAddBoundary.Text = "Add";
-            this.btnAddBoundary.UseVisualStyleBackColor = true;
-            this.btnAddBoundary.Click += new System.EventHandler(this.btnAddBoundary_Click);
-            // 
-            // CancelButton2
-            // 
-            this.CancelButton2.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.CancelButton2.Location = new System.Drawing.Point(328, 261);
-            this.CancelButton2.Name = "CancelButton2";
-            this.CancelButton2.Size = new System.Drawing.Size(75, 23);
-            this.CancelButton2.TabIndex = 18;
-            this.CancelButton2.Text = "Cancel";
-            this.CancelButton2.UseVisualStyleBackColor = true;
-            this.CancelButton2.Click += new System.EventHandler(this.CancelButton2_Click);
-            // 
-            // AcceptButton2
-            // 
-            this.AcceptButton2.Location = new System.Drawing.Point(405, 261);
-            this.AcceptButton2.Name = "AcceptButton2";
-            this.AcceptButton2.Size = new System.Drawing.Size(75, 23);
-            this.AcceptButton2.TabIndex = 19;
-            this.AcceptButton2.Text = "Accept";
-            this.AcceptButton2.UseVisualStyleBackColor = true;
-            this.AcceptButton2.Click += new System.EventHandler(this.AcceptButton2_Click);
-            // 
-            // lblBoundaries
-            // 
-            this.lblBoundaries.AutoSize = true;
-            this.lblBoundaries.Location = new System.Drawing.Point(8, 93);
-            this.lblBoundaries.Name = "lblBoundaries";
-            this.lblBoundaries.Size = new System.Drawing.Size(63, 13);
-            this.lblBoundaries.TabIndex = 36;
-            this.lblBoundaries.Text = "Boundaries:";
-            // 
-            // lstBoundaries
-            // 
-            this.lstBoundaries.FormattingEnabled = true;
-            this.lstBoundaries.Location = new System.Drawing.Point(85, 116);
-            this.lstBoundaries.Name = "lstBoundaries";
-            this.lstBoundaries.Size = new System.Drawing.Size(156, 160);
-            this.lstBoundaries.TabIndex = 12;
-            // 
-            // lblText
-            // 
-            this.lblText.AutoSize = true;
-            this.lblText.Location = new System.Drawing.Point(8, 14);
-            this.lblText.Name = "lblText";
-            this.lblText.Size = new System.Drawing.Size(31, 13);
-            this.lblText.TabIndex = 34;
-            this.lblText.Text = "Text:";
-            // 
-            // txtText
-            // 
-            this.txtText.Location = new System.Drawing.Point(85, 11);
-            this.txtText.Name = "txtText";
-            this.txtText.Size = new System.Drawing.Size(156, 20);
-            this.txtText.TabIndex = 0;
-            // 
-            // lblTextPosition
-            // 
-            this.lblTextPosition.AutoSize = true;
-            this.lblTextPosition.Location = new System.Drawing.Point(8, 67);
-            this.lblTextPosition.Name = "lblTextPosition";
-            this.lblTextPosition.Size = new System.Drawing.Size(71, 13);
-            this.lblTextPosition.TabIndex = 31;
-            this.lblTextPosition.Text = "Text Position:";
-            // 
-            // lblShiftText
-            // 
-            this.lblShiftText.AutoSize = true;
-            this.lblShiftText.Location = new System.Drawing.Point(8, 40);
-            this.lblShiftText.Name = "lblShiftText";
-            this.lblShiftText.Size = new System.Drawing.Size(55, 13);
-            this.lblShiftText.TabIndex = 45;
-            this.lblShiftText.Text = "Shift Text:";
-            // 
-            // txtShiftText
-            // 
-            this.txtShiftText.Location = new System.Drawing.Point(85, 37);
-            this.txtShiftText.Name = "txtShiftText";
-            this.txtShiftText.Size = new System.Drawing.Size(156, 20);
-            this.txtShiftText.TabIndex = 2;
-            // 
-            // lstKeyCodes
-            // 
-            this.lstKeyCodes.FormattingEnabled = true;
-            this.lstKeyCodes.Location = new System.Drawing.Point(328, 64);
-            this.lstKeyCodes.Name = "lstKeyCodes";
-            this.lstKeyCodes.Size = new System.Drawing.Size(151, 186);
-            this.lstKeyCodes.TabIndex = 17;
-            // 
-            // btnRemoveKeyCode
-            // 
-            this.btnRemoveKeyCode.Location = new System.Drawing.Point(247, 93);
-            this.btnRemoveKeyCode.Name = "btnRemoveKeyCode";
-            this.btnRemoveKeyCode.Size = new System.Drawing.Size(75, 23);
-            this.btnRemoveKeyCode.TabIndex = 15;
-            this.btnRemoveKeyCode.Text = "Remove";
-            this.btnRemoveKeyCode.UseVisualStyleBackColor = true;
-            this.btnRemoveKeyCode.Click += new System.EventHandler(this.btnRemoveKeyCode_Click);
-            // 
-            // btnAddKeyCode
-            // 
-            this.btnAddKeyCode.Location = new System.Drawing.Point(247, 64);
-            this.btnAddKeyCode.Name = "btnAddKeyCode";
-            this.btnAddKeyCode.Size = new System.Drawing.Size(75, 23);
-            this.btnAddKeyCode.TabIndex = 14;
-            this.btnAddKeyCode.Text = "Add";
-            this.btnAddKeyCode.UseVisualStyleBackColor = true;
-            this.btnAddKeyCode.Click += new System.EventHandler(this.btnAddKeyCode_Click);
-            // 
-            // udKeyCode
-            // 
-            this.udKeyCode.Location = new System.Drawing.Point(329, 38);
-            this.udKeyCode.Maximum = new decimal(new int[] {
-            1028,
-            0,
-            0,
-            0});
-            this.udKeyCode.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.udKeyCode.Name = "udKeyCode";
-            this.udKeyCode.Size = new System.Drawing.Size(151, 20);
-            this.udKeyCode.TabIndex = 13;
-            this.udKeyCode.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            // 
-            // lblKeyCodes
-            // 
-            this.lblKeyCodes.AutoSize = true;
-            this.lblKeyCodes.Location = new System.Drawing.Point(247, 40);
-            this.lblKeyCodes.Name = "lblKeyCodes";
-            this.lblKeyCodes.Size = new System.Drawing.Size(60, 13);
-            this.lblKeyCodes.TabIndex = 51;
-            this.lblKeyCodes.Text = "Key codes:";
-            // 
-            // chkChangeOnCaps
-            // 
-            this.chkChangeOnCaps.AutoSize = true;
-            this.chkChangeOnCaps.Location = new System.Drawing.Point(250, 9);
-            this.chkChangeOnCaps.Name = "chkChangeOnCaps";
-            this.chkChangeOnCaps.Size = new System.Drawing.Size(216, 17);
-            this.chkChangeOnCaps.TabIndex = 1;
-            this.chkChangeOnCaps.Text = "Change capitalization on Caps Lock key";
-            this.chkChangeOnCaps.UseVisualStyleBackColor = true;
-            // 
-            // btnUpdateBoundary
-            // 
-            this.btnUpdateBoundary.Location = new System.Drawing.Point(4, 145);
-            this.btnUpdateBoundary.Name = "btnUpdateBoundary";
-            this.btnUpdateBoundary.Size = new System.Drawing.Size(75, 23);
-            this.btnUpdateBoundary.TabIndex = 7;
-            this.btnUpdateBoundary.Text = "Update";
-            this.btnUpdateBoundary.UseVisualStyleBackColor = true;
-            this.btnUpdateBoundary.Click += new System.EventHandler(this.btnUpdateBoundary_Click);
-            // 
-            // btnCenterText
-            // 
-            this.btnCenterText.Location = new System.Drawing.Point(168, 62);
-            this.btnCenterText.Name = "btnCenterText";
-            this.btnCenterText.Size = new System.Drawing.Size(73, 23);
-            this.btnCenterText.TabIndex = 4;
-            this.btnCenterText.Text = "Center";
-            this.btnCenterText.UseVisualStyleBackColor = true;
-            this.btnCenterText.Click += new System.EventHandler(this.btnCenterText_Click);
-            // 
-            // btnRectangle
-            // 
-            this.btnRectangle.Location = new System.Drawing.Point(4, 261);
-            this.btnRectangle.Name = "btnRectangle";
-            this.btnRectangle.Size = new System.Drawing.Size(75, 23);
-            this.btnRectangle.TabIndex = 11;
-            this.btnRectangle.Text = "Rectangle";
-            this.btnRectangle.UseVisualStyleBackColor = true;
-            this.btnRectangle.Click += new System.EventHandler(this.btnRectangle_Click);
-            // 
-            // btnDetectKeyCode
-            // 
-            this.btnDetectKeyCode.Location = new System.Drawing.Point(247, 122);
-            this.btnDetectKeyCode.Name = "btnDetectKeyCode";
-            this.btnDetectKeyCode.Size = new System.Drawing.Size(75, 23);
-            this.btnDetectKeyCode.TabIndex = 16;
-            this.btnDetectKeyCode.Text = "Detect";
-            this.btnDetectKeyCode.UseVisualStyleBackColor = true;
-            this.btnDetectKeyCode.Click += new System.EventHandler(this.btnDetectKeyCode_Click);
-            // 
-            // txtBoundaries
-            // 
-            this.txtBoundaries.Location = new System.Drawing.Point(85, 90);
-            this.txtBoundaries.MaxVal = 2147483647;
-            this.txtBoundaries.Name = "txtBoundaries";
-            this.txtBoundaries.Separator = ';';
-            this.txtBoundaries.Size = new System.Drawing.Size(156, 20);
-            this.txtBoundaries.SpacesAroundSeparator = true;
-            this.txtBoundaries.TabIndex = 5;
-            this.txtBoundaries.Text = "0 ; 0";
-            this.txtBoundaries.X = 0;
-            this.txtBoundaries.Y = 0;
-            // 
-            // txtTextPosition
-            // 
-            this.txtTextPosition.Location = new System.Drawing.Point(85, 64);
-            this.txtTextPosition.MaxVal = 2147483647;
-            this.txtTextPosition.Name = "txtTextPosition";
-            this.txtTextPosition.Separator = ';';
-            this.txtTextPosition.Size = new System.Drawing.Size(156, 20);
-            this.txtTextPosition.SpacesAroundSeparator = true;
-            this.txtTextPosition.TabIndex = 3;
-            this.txtTextPosition.Text = "0 ; 0";
-            this.txtTextPosition.X = 0;
-            this.txtTextPosition.Y = 0;
-            // 
-            // KeyboardKeyPropertiesForm
-            // 
-            this.AcceptButton = this.AcceptButton2;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.CancelButton = this.CancelButton2;
-            this.ClientSize = new System.Drawing.Size(492, 293);
-            this.Controls.Add(this.btnUpdateBoundary);
-            this.Controls.Add(this.btnCenterText);
-            this.Controls.Add(this.btnRectangle);
-            this.Controls.Add(this.btnDetectKeyCode);
-            this.Controls.Add(this.chkChangeOnCaps);
-            this.Controls.Add(this.lblKeyCodes);
-            this.Controls.Add(this.udKeyCode);
-            this.Controls.Add(this.btnRemoveKeyCode);
-            this.Controls.Add(this.btnAddKeyCode);
-            this.Controls.Add(this.lstKeyCodes);
-            this.Controls.Add(this.lblShiftText);
-            this.Controls.Add(this.txtShiftText);
-            this.Controls.Add(this.btnBoundaryDown);
-            this.Controls.Add(this.btnBoundaryUp);
-            this.Controls.Add(this.btnRemoveBoundary);
-            this.Controls.Add(this.btnAddBoundary);
-            this.Controls.Add(this.txtBoundaries);
-            this.Controls.Add(this.CancelButton2);
-            this.Controls.Add(this.AcceptButton2);
-            this.Controls.Add(this.lblBoundaries);
-            this.Controls.Add(this.lstBoundaries);
-            this.Controls.Add(this.lblText);
-            this.Controls.Add(this.txtText);
-            this.Controls.Add(this.txtTextPosition);
-            this.Controls.Add(this.lblTextPosition);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
-            this.Name = "KeyboardKeyPropertiesForm";
-            this.ShowInTaskbar = false;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Keyboard Key Properties";
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.KeyboardKeyPropertiesForm_FormClosing);
-            this.Load += new System.EventHandler(this.KeyboardKeyPropertiesForm_Load);
-            ((System.ComponentModel.ISupportInitialize)(this.udKeyCode)).EndInit();
-            this.ResumeLayout(false);
-            this.PerformLayout();
+		/// <summary>
+		/// Required method for Designer support - do not modify
+		/// the contents of this method with the code editor.
+		/// </summary>
+		private void InitializeComponent()
+		{
+			this.btnBoundaryDown = new System.Windows.Forms.Button();
+			this.btnBoundaryUp = new System.Windows.Forms.Button();
+			this.btnRemoveBoundary = new System.Windows.Forms.Button();
+			this.btnAddBoundary = new System.Windows.Forms.Button();
+			this.CancelButton2 = new System.Windows.Forms.Button();
+			this.AcceptButton2 = new System.Windows.Forms.Button();
+			this.lblBoundaries = new System.Windows.Forms.Label();
+			this.lstBoundaries = new System.Windows.Forms.ListBox();
+			this.lblText = new System.Windows.Forms.Label();
+			this.txtText = new System.Windows.Forms.TextBox();
+			this.lblTextPosition = new System.Windows.Forms.Label();
+			this.lblShiftText = new System.Windows.Forms.Label();
+			this.txtShiftText = new System.Windows.Forms.TextBox();
+			this.lstKeyCodes = new System.Windows.Forms.ListBox();
+			this.btnRemoveKeyCode = new System.Windows.Forms.Button();
+			this.btnAddKeyCode = new System.Windows.Forms.Button();
+			this.udKeyCode = new System.Windows.Forms.NumericUpDown();
+			this.lblKeyCodes = new System.Windows.Forms.Label();
+			this.chkChangeOnCaps = new System.Windows.Forms.CheckBox();
+			this.btnUpdateBoundary = new System.Windows.Forms.Button();
+			this.btnCenterText = new System.Windows.Forms.Button();
+			this.btnRectangle = new System.Windows.Forms.Button();
+			this.btnDetectKeyCode = new System.Windows.Forms.Button();
+			this.txtBoundaries = new ThoNohT.NohBoard.Controls.VectorTextBox();
+			this.txtTextPosition = new ThoNohT.NohBoard.Controls.VectorTextBox();
+			keyCodesOrModeCheckbox = new System.Windows.Forms.CheckBox();
+			((System.ComponentModel.ISupportInitialize)(this.udKeyCode)).BeginInit();
+			this.SuspendLayout();
+			// 
+			// btnBoundaryDown
+			// 
+			this.btnBoundaryDown.Location = new System.Drawing.Point(4, 232);
+			this.btnBoundaryDown.Name = "btnBoundaryDown";
+			this.btnBoundaryDown.Size = new System.Drawing.Size(75, 23);
+			this.btnBoundaryDown.TabIndex = 10;
+			this.btnBoundaryDown.Text = "Down";
+			this.btnBoundaryDown.UseVisualStyleBackColor = true;
+			this.btnBoundaryDown.Click += new System.EventHandler(this.btnBoundaryDown_Click);
+			// 
+			// btnBoundaryUp
+			// 
+			this.btnBoundaryUp.Location = new System.Drawing.Point(4, 203);
+			this.btnBoundaryUp.Name = "btnBoundaryUp";
+			this.btnBoundaryUp.Size = new System.Drawing.Size(75, 23);
+			this.btnBoundaryUp.TabIndex = 9;
+			this.btnBoundaryUp.Text = "Up";
+			this.btnBoundaryUp.UseVisualStyleBackColor = true;
+			this.btnBoundaryUp.Click += new System.EventHandler(this.btnBoundaryUp_Click);
+			// 
+			// btnRemoveBoundary
+			// 
+			this.btnRemoveBoundary.Location = new System.Drawing.Point(4, 174);
+			this.btnRemoveBoundary.Name = "btnRemoveBoundary";
+			this.btnRemoveBoundary.Size = new System.Drawing.Size(75, 23);
+			this.btnRemoveBoundary.TabIndex = 8;
+			this.btnRemoveBoundary.Text = "Remove";
+			this.btnRemoveBoundary.UseVisualStyleBackColor = true;
+			this.btnRemoveBoundary.Click += new System.EventHandler(this.btnRemoveBoundary_Click);
+			// 
+			// btnAddBoundary
+			// 
+			this.btnAddBoundary.Location = new System.Drawing.Point(4, 116);
+			this.btnAddBoundary.Name = "btnAddBoundary";
+			this.btnAddBoundary.Size = new System.Drawing.Size(75, 23);
+			this.btnAddBoundary.TabIndex = 6;
+			this.btnAddBoundary.Text = "Add";
+			this.btnAddBoundary.UseVisualStyleBackColor = true;
+			this.btnAddBoundary.Click += new System.EventHandler(this.btnAddBoundary_Click);
+			// 
+			// CancelButton2
+			// 
+			this.CancelButton2.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+			this.CancelButton2.Location = new System.Drawing.Point(328, 261);
+			this.CancelButton2.Name = "CancelButton2";
+			this.CancelButton2.Size = new System.Drawing.Size(75, 23);
+			this.CancelButton2.TabIndex = 18;
+			this.CancelButton2.Text = "Cancel";
+			this.CancelButton2.UseVisualStyleBackColor = true;
+			this.CancelButton2.Click += new System.EventHandler(this.CancelButton2_Click);
+			// 
+			// AcceptButton2
+			// 
+			this.AcceptButton2.Location = new System.Drawing.Point(405, 261);
+			this.AcceptButton2.Name = "AcceptButton2";
+			this.AcceptButton2.Size = new System.Drawing.Size(75, 23);
+			this.AcceptButton2.TabIndex = 19;
+			this.AcceptButton2.Text = "Accept";
+			this.AcceptButton2.UseVisualStyleBackColor = true;
+			this.AcceptButton2.Click += new System.EventHandler(this.AcceptButton2_Click);
+			// 
+			// lblBoundaries
+			// 
+			this.lblBoundaries.AutoSize = true;
+			this.lblBoundaries.Location = new System.Drawing.Point(8, 93);
+			this.lblBoundaries.Name = "lblBoundaries";
+			this.lblBoundaries.Size = new System.Drawing.Size(63, 13);
+			this.lblBoundaries.TabIndex = 36;
+			this.lblBoundaries.Text = "Boundaries:";
+			// 
+			// lstBoundaries
+			// 
+			this.lstBoundaries.FormattingEnabled = true;
+			this.lstBoundaries.Location = new System.Drawing.Point(85, 116);
+			this.lstBoundaries.Name = "lstBoundaries";
+			this.lstBoundaries.Size = new System.Drawing.Size(156, 160);
+			this.lstBoundaries.TabIndex = 12;
+			// 
+			// lblText
+			// 
+			this.lblText.AutoSize = true;
+			this.lblText.Location = new System.Drawing.Point(8, 14);
+			this.lblText.Name = "lblText";
+			this.lblText.Size = new System.Drawing.Size(31, 13);
+			this.lblText.TabIndex = 34;
+			this.lblText.Text = "Text:";
+			// 
+			// txtText
+			// 
+			this.txtText.Location = new System.Drawing.Point(85, 11);
+			this.txtText.Name = "txtText";
+			this.txtText.Size = new System.Drawing.Size(156, 20);
+			this.txtText.TabIndex = 0;
+			// 
+			// lblTextPosition
+			// 
+			this.lblTextPosition.AutoSize = true;
+			this.lblTextPosition.Location = new System.Drawing.Point(8, 67);
+			this.lblTextPosition.Name = "lblTextPosition";
+			this.lblTextPosition.Size = new System.Drawing.Size(71, 13);
+			this.lblTextPosition.TabIndex = 31;
+			this.lblTextPosition.Text = "Text Position:";
+			// 
+			// lblShiftText
+			// 
+			this.lblShiftText.AutoSize = true;
+			this.lblShiftText.Location = new System.Drawing.Point(8, 40);
+			this.lblShiftText.Name = "lblShiftText";
+			this.lblShiftText.Size = new System.Drawing.Size(55, 13);
+			this.lblShiftText.TabIndex = 45;
+			this.lblShiftText.Text = "Shift Text:";
+			// 
+			// txtShiftText
+			// 
+			this.txtShiftText.Location = new System.Drawing.Point(85, 37);
+			this.txtShiftText.Name = "txtShiftText";
+			this.txtShiftText.Size = new System.Drawing.Size(156, 20);
+			this.txtShiftText.TabIndex = 2;
+			// 
+			// lstKeyCodes
+			// 
+			this.lstKeyCodes.FormattingEnabled = true;
+			this.lstKeyCodes.Location = new System.Drawing.Point(328, 64);
+			this.lstKeyCodes.Name = "lstKeyCodes";
+			this.lstKeyCodes.Size = new System.Drawing.Size(151, 166);
+			this.lstKeyCodes.TabIndex = 17;
+			// 
+			// btnRemoveKeyCode
+			// 
+			this.btnRemoveKeyCode.Location = new System.Drawing.Point(247, 93);
+			this.btnRemoveKeyCode.Name = "btnRemoveKeyCode";
+			this.btnRemoveKeyCode.Size = new System.Drawing.Size(75, 23);
+			this.btnRemoveKeyCode.TabIndex = 15;
+			this.btnRemoveKeyCode.Text = "Remove";
+			this.btnRemoveKeyCode.UseVisualStyleBackColor = true;
+			this.btnRemoveKeyCode.Click += new System.EventHandler(this.btnRemoveKeyCode_Click);
+			// 
+			// btnAddKeyCode
+			// 
+			this.btnAddKeyCode.Location = new System.Drawing.Point(247, 64);
+			this.btnAddKeyCode.Name = "btnAddKeyCode";
+			this.btnAddKeyCode.Size = new System.Drawing.Size(75, 23);
+			this.btnAddKeyCode.TabIndex = 14;
+			this.btnAddKeyCode.Text = "Add";
+			this.btnAddKeyCode.UseVisualStyleBackColor = true;
+			this.btnAddKeyCode.Click += new System.EventHandler(this.btnAddKeyCode_Click);
+			// 
+			// udKeyCode
+			// 
+			this.udKeyCode.Location = new System.Drawing.Point(329, 38);
+			this.udKeyCode.Maximum = new decimal(new int[] {
+			1028,
+			0,
+			0,
+			0});
+			this.udKeyCode.Minimum = new decimal(new int[] {
+			1,
+			0,
+			0,
+			0});
+			this.udKeyCode.Name = "udKeyCode";
+			this.udKeyCode.Size = new System.Drawing.Size(151, 20);
+			this.udKeyCode.TabIndex = 13;
+			this.udKeyCode.Value = new decimal(new int[] {
+			1,
+			0,
+			0,
+			0});
+			// 
+			// lblKeyCodes
+			// 
+			this.lblKeyCodes.AutoSize = true;
+			this.lblKeyCodes.Location = new System.Drawing.Point(247, 40);
+			this.lblKeyCodes.Name = "lblKeyCodes";
+			this.lblKeyCodes.Size = new System.Drawing.Size(60, 13);
+			this.lblKeyCodes.TabIndex = 51;
+			this.lblKeyCodes.Text = "Key codes:";
+			// 
+			// chkChangeOnCaps
+			// 
+			this.chkChangeOnCaps.AutoSize = true;
+			this.chkChangeOnCaps.Location = new System.Drawing.Point(250, 9);
+			this.chkChangeOnCaps.Name = "chkChangeOnCaps";
+			this.chkChangeOnCaps.Size = new System.Drawing.Size(216, 17);
+			this.chkChangeOnCaps.TabIndex = 1;
+			this.chkChangeOnCaps.Text = "Change capitalization on Caps Lock key";
+			this.chkChangeOnCaps.UseVisualStyleBackColor = true;
+			// 
+			// btnUpdateBoundary
+			// 
+			this.btnUpdateBoundary.Location = new System.Drawing.Point(4, 145);
+			this.btnUpdateBoundary.Name = "btnUpdateBoundary";
+			this.btnUpdateBoundary.Size = new System.Drawing.Size(75, 23);
+			this.btnUpdateBoundary.TabIndex = 7;
+			this.btnUpdateBoundary.Text = "Update";
+			this.btnUpdateBoundary.UseVisualStyleBackColor = true;
+			this.btnUpdateBoundary.Click += new System.EventHandler(this.btnUpdateBoundary_Click);
+			// 
+			// btnCenterText
+			// 
+			this.btnCenterText.Location = new System.Drawing.Point(168, 62);
+			this.btnCenterText.Name = "btnCenterText";
+			this.btnCenterText.Size = new System.Drawing.Size(73, 23);
+			this.btnCenterText.TabIndex = 4;
+			this.btnCenterText.Text = "Center";
+			this.btnCenterText.UseVisualStyleBackColor = true;
+			this.btnCenterText.Click += new System.EventHandler(this.btnCenterText_Click);
+			// 
+			// btnRectangle
+			// 
+			this.btnRectangle.Location = new System.Drawing.Point(4, 261);
+			this.btnRectangle.Name = "btnRectangle";
+			this.btnRectangle.Size = new System.Drawing.Size(75, 23);
+			this.btnRectangle.TabIndex = 11;
+			this.btnRectangle.Text = "Rectangle";
+			this.btnRectangle.UseVisualStyleBackColor = true;
+			this.btnRectangle.Click += new System.EventHandler(this.btnRectangle_Click);
+			// 
+			// btnDetectKeyCode
+			// 
+			this.btnDetectKeyCode.Location = new System.Drawing.Point(247, 122);
+			this.btnDetectKeyCode.Name = "btnDetectKeyCode";
+			this.btnDetectKeyCode.Size = new System.Drawing.Size(75, 23);
+			this.btnDetectKeyCode.TabIndex = 16;
+			this.btnDetectKeyCode.Text = "Detect";
+			this.btnDetectKeyCode.UseVisualStyleBackColor = true;
+			this.btnDetectKeyCode.Click += new System.EventHandler(this.btnDetectKeyCode_Click);
+			// 
+			// txtBoundaries
+			// 
+			this.txtBoundaries.Location = new System.Drawing.Point(85, 90);
+			this.txtBoundaries.MaxVal = 2147483647;
+			this.txtBoundaries.Name = "txtBoundaries";
+			this.txtBoundaries.Separator = ';';
+			this.txtBoundaries.Size = new System.Drawing.Size(156, 20);
+			this.txtBoundaries.SpacesAroundSeparator = true;
+			this.txtBoundaries.TabIndex = 5;
+			this.txtBoundaries.Text = "0 ; 0";
+			this.txtBoundaries.X = 0;
+			this.txtBoundaries.Y = 0;
+			// 
+			// txtTextPosition
+			// 
+			this.txtTextPosition.Location = new System.Drawing.Point(85, 64);
+			this.txtTextPosition.MaxVal = 2147483647;
+			this.txtTextPosition.Name = "txtTextPosition";
+			this.txtTextPosition.Separator = ';';
+			this.txtTextPosition.Size = new System.Drawing.Size(156, 20);
+			this.txtTextPosition.SpacesAroundSeparator = true;
+			this.txtTextPosition.TabIndex = 3;
+			this.txtTextPosition.Text = "0 ; 0";
+			this.txtTextPosition.X = 0;
+			this.txtTextPosition.Y = 0;
+			// 
+			// keyCodesOrModeCheckbox
+			// 
+			keyCodesOrModeCheckbox.AutoSize = true;
+			keyCodesOrModeCheckbox.CheckState = System.Windows.Forms.CheckState.Checked;
+			keyCodesOrModeCheckbox.Location = new System.Drawing.Point(328, 236);
+			keyCodesOrModeCheckbox.Margin = new System.Windows.Forms.Padding(5, 3, 5, 3);
+			keyCodesOrModeCheckbox.Name = "keyCodesOrModeCheckbox";
+			keyCodesOrModeCheckbox.Size = new System.Drawing.Size(143, 19);
+			keyCodesOrModeCheckbox.TabIndex = 52;
+			keyCodesOrModeCheckbox.Text = "Key Codes OR Mode";
+			keyCodesOrModeCheckbox.UseVisualStyleBackColor = true;
+			keyCodesOrModeCheckbox.CheckedChanged += keyCodesOrModeCheckbox_CheckedChanged;
+			// 
+			// KeyboardKeyPropertiesForm
+			// 
+			this.AcceptButton = this.AcceptButton2;
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.CancelButton = this.CancelButton2;
+			this.ClientSize = new System.Drawing.Size(492, 293);
+			Controls.Add(keyCodesOrModeCheckbox);
+			this.Controls.Add(this.btnCenterText);
+			this.Controls.Add(this.btnRectangle);
+			this.Controls.Add(this.btnDetectKeyCode);
+			this.Controls.Add(this.chkChangeOnCaps);
+			this.Controls.Add(this.lblKeyCodes);
+			this.Controls.Add(this.udKeyCode);
+			this.Controls.Add(this.btnRemoveKeyCode);
+			this.Controls.Add(this.btnAddKeyCode);
+			this.Controls.Add(this.lstKeyCodes);
+			this.Controls.Add(this.lblShiftText);
+			this.Controls.Add(this.txtShiftText);
+			this.Controls.Add(this.btnBoundaryDown);
+			this.Controls.Add(this.btnBoundaryUp);
+			this.Controls.Add(this.btnRemoveBoundary);
+			this.Controls.Add(this.btnAddBoundary);
+			this.Controls.Add(this.txtBoundaries);
+			this.Controls.Add(this.CancelButton2);
+			this.Controls.Add(this.AcceptButton2);
+			this.Controls.Add(this.lblBoundaries);
+			this.Controls.Add(this.lstBoundaries);
+			this.Controls.Add(this.lblText);
+			this.Controls.Add(this.txtText);
+			this.Controls.Add(this.txtTextPosition);
+			this.Controls.Add(this.lblTextPosition);
+			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
+			this.Name = "KeyboardKeyPropertiesForm";
+			this.ShowInTaskbar = false;
+			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+			this.Text = "Keyboard Key Properties";
+			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.KeyboardKeyPropertiesForm_FormClosing);
+			this.Load += new System.EventHandler(this.KeyboardKeyPropertiesForm_Load);
+			((System.ComponentModel.ISupportInitialize)(this.udKeyCode)).EndInit();
+			this.ResumeLayout(false);
+			this.PerformLayout();
 
-        }
+		}
 
-        #endregion
+		#endregion
 
-        private System.Windows.Forms.Button btnBoundaryDown;
-        private System.Windows.Forms.Button btnBoundaryUp;
-        private System.Windows.Forms.Button btnRemoveBoundary;
-        private System.Windows.Forms.Button btnAddBoundary;
-        private Controls.VectorTextBox txtBoundaries;
-        private System.Windows.Forms.Button CancelButton2;
-        private System.Windows.Forms.Button AcceptButton2;
-        private System.Windows.Forms.Label lblBoundaries;
-        private System.Windows.Forms.ListBox lstBoundaries;
-        private System.Windows.Forms.Label lblText;
-        private System.Windows.Forms.TextBox txtText;
-        private Controls.VectorTextBox txtTextPosition;
-        private System.Windows.Forms.Label lblTextPosition;
-        private System.Windows.Forms.Label lblShiftText;
-        private System.Windows.Forms.TextBox txtShiftText;
-        private System.Windows.Forms.ListBox lstKeyCodes;
-        private System.Windows.Forms.Button btnRemoveKeyCode;
-        private System.Windows.Forms.Button btnAddKeyCode;
-        private System.Windows.Forms.NumericUpDown udKeyCode;
-        private System.Windows.Forms.Label lblKeyCodes;
-        private System.Windows.Forms.CheckBox chkChangeOnCaps;
-        private System.Windows.Forms.Button btnUpdateBoundary;
-        private System.Windows.Forms.Button btnCenterText;
-        private System.Windows.Forms.Button btnRectangle;
-        private System.Windows.Forms.Button btnDetectKeyCode;
-    }
+		private System.Windows.Forms.Button btnBoundaryDown;
+		private System.Windows.Forms.Button btnBoundaryUp;
+		private System.Windows.Forms.Button btnRemoveBoundary;
+		private System.Windows.Forms.Button btnAddBoundary;
+		private Controls.VectorTextBox txtBoundaries;
+		private System.Windows.Forms.Button CancelButton2;
+		private System.Windows.Forms.Button AcceptButton2;
+		private System.Windows.Forms.Label lblBoundaries;
+		private System.Windows.Forms.ListBox lstBoundaries;
+		private System.Windows.Forms.Label lblText;
+		private System.Windows.Forms.TextBox txtText;
+		private Controls.VectorTextBox txtTextPosition;
+		private System.Windows.Forms.Label lblTextPosition;
+		private System.Windows.Forms.Label lblShiftText;
+		private System.Windows.Forms.TextBox txtShiftText;
+		private System.Windows.Forms.ListBox lstKeyCodes;
+		private System.Windows.Forms.Button btnRemoveKeyCode;
+		private System.Windows.Forms.Button btnAddKeyCode;
+		private System.Windows.Forms.NumericUpDown udKeyCode;
+		private System.Windows.Forms.Label lblKeyCodes;
+		private System.Windows.Forms.CheckBox chkChangeOnCaps;
+		private System.Windows.Forms.Button btnUpdateBoundary;
+		private System.Windows.Forms.Button btnCenterText;
+		private System.Windows.Forms.Button btnRectangle;
+		private System.Windows.Forms.Button btnDetectKeyCode;
+		private System.Windows.Forms.CheckBox keyCodesOrModeCheckbox;
+	}
 }

--- a/NohBoard/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.cs
+++ b/NohBoard/NohBoard/Forms/Properties/KeyboardKeyPropertiesForm.cs
@@ -17,376 +17,387 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace ThoNohT.NohBoard.Forms.Properties
 {
-    using System;
-    using System.Linq;
-    using System.Windows.Forms;
-    using Extra;
-    using Keyboard.ElementDefinitions;
+	using System;
+	using System.Linq;
+	using System.Windows.Forms;
+	using Extra;
+	using Keyboard.ElementDefinitions;
 
-    /// <summary>
-    /// The form used to update the properties of a keyboard key.
-    /// </summary>
-    public partial class KeyboardKeyPropertiesForm : Form
-    {
-        #region Fields
+	/// <summary>
+	/// The form used to update the properties of a keyboard key.
+	/// </summary>
+	public partial class KeyboardKeyPropertiesForm : Form
+	{
+		#region Fields
 
-        /// <summary>
-        /// A backup definition to return to if the user pressed cancel.
-        /// </summary>
-        private readonly KeyboardKeyDefinition initialDefinition;
+		/// <summary>
+		/// A backup definition to return to if the user pressed cancel.
+		/// </summary>
+		private readonly KeyboardKeyDefinition initialDefinition;
 
-        /// <summary>
-        /// The currently loaded definition.
-        /// </summary>
-        private KeyboardKeyDefinition currentDefinition;
+		/// <summary>
+		/// The currently loaded definition.
+		/// </summary>
+		private KeyboardKeyDefinition currentDefinition;
 
-        /// <summary>
-        /// Indicates whether we are currently detecting key pressed via the <see cref="Hooking.Interop.HookManager"/>.
-        /// </summary>
-        private bool detectingKeyCode;
+		/// <summary>
+		/// Indicates whether we are currently detecting key pressed via the <see cref="Hooking.Interop.HookManager"/>.
+		/// </summary>
+		private bool detectingKeyCode;
 
-        #endregion Fields
+		#endregion Fields
 
-        #region Events
+		#region Events
 
-        /// <summary>
-        /// The event that is invoked when the definition has been changed. Only invoked when the definition is changed
-        /// through the user interface, not when it is changed programmatically.
-        /// </summary>
-        public event Action<KeyboardKeyDefinition> DefinitionChanged;
+		/// <summary>
+		/// The event that is invoked when the definition has been changed. Only invoked when the definition is changed
+		/// through the user interface, not when it is changed programmatically.
+		/// </summary>
+		public event Action<KeyboardKeyDefinition> DefinitionChanged;
 
-        /// <summary>
-        /// The event that is invoked when the definition is saved.
-        /// </summary>
-        public event Action DefinitionSaved;
+		/// <summary>
+		/// The event that is invoked when the definition is saved.
+		/// </summary>
+		public event Action DefinitionSaved;
 
-        #endregion Events
+		#endregion Events
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="KeyboardKeyPropertiesForm" /> class.
-        /// </summary>
-        public KeyboardKeyPropertiesForm(KeyboardKeyDefinition initialDefinition)
-        {
-            this.initialDefinition = initialDefinition;
-            this.currentDefinition = (KeyboardKeyDefinition) initialDefinition.Clone();
-            this.InitializeComponent();
-        }
+		/// <summary>
+		/// Initializes a new instance of the <see cref="KeyboardKeyPropertiesForm" /> class.
+		/// </summary>
+		public KeyboardKeyPropertiesForm(KeyboardKeyDefinition initialDefinition)
+		{
+			this.initialDefinition = initialDefinition;
+			this.currentDefinition = (KeyboardKeyDefinition)initialDefinition.Clone();
+			this.InitializeComponent();
+		}
 
-        /// <summary>
-        /// Loads the form, setting the controls to the initial style.
-        /// </summary>
-        private void KeyboardKeyPropertiesForm_Load(object sender, EventArgs e)
-        {
-            this.txtText.Text = this.initialDefinition.Text;
-            this.txtShiftText.Text = this.initialDefinition.ShiftText;
-            this.txtTextPosition.X = this.initialDefinition.TextPosition.X;
-            this.txtTextPosition.Y = this.initialDefinition.TextPosition.Y;
-            this.lstBoundaries.Items.AddRange(this.initialDefinition.Boundaries.Cast<object>().ToArray());
-            this.lstKeyCodes.Items.AddRange(
-                this.initialDefinition.KeyCodes.Select(x => x).Cast<object>().ToArray());
-            this.chkChangeOnCaps.Checked = this.initialDefinition.ChangeOnCaps;
+		/// <summary>
+		/// Loads the form, setting the controls to the initial style.
+		/// </summary>
+		private void KeyboardKeyPropertiesForm_Load(object sender, EventArgs e)
+		{
+			this.txtText.Text = this.initialDefinition.Text;
+			this.txtShiftText.Text = this.initialDefinition.ShiftText;
+			this.txtTextPosition.X = this.initialDefinition.TextPosition.X;
+			this.txtTextPosition.Y = this.initialDefinition.TextPosition.Y;
+			this.lstBoundaries.Items.AddRange(this.initialDefinition.Boundaries.Cast<object>().ToArray());
+			this.lstKeyCodes.Items.AddRange(
+				this.initialDefinition.KeyCodes.Select(x => x).Cast<object>().ToArray());
+			this.chkChangeOnCaps.Checked = this.initialDefinition.ChangeOnCaps;
+			this.keyCodesOrModeCheckbox.Checked = this.initialDefinition.KeyCodesOrMode;
 
-            // Only add the event handlers after the initial properties have been set.
-            this.lstBoundaries.SelectedIndexChanged += this.lstBoundaries_SelectedIndexChanged;
-            this.txtText.TextChanged += this.txtText_TextChanged;
-            this.txtTextPosition.ValueChanged += this.txtTextPosition_ValueChanged;
-            this.txtShiftText.TextChanged += this.txtShiftText_TextChanged;
-            this.lstKeyCodes.SelectedIndexChanged += this.lstKeyCodes_SelectedIndexChanged;
-            this.chkChangeOnCaps.CheckedChanged += this.chkChangeOnCaps_CheckedChanged;
-        }
+			// Only add the event handlers after the initial properties have been set.
+			this.lstBoundaries.SelectedIndexChanged += this.lstBoundaries_SelectedIndexChanged;
+			this.txtText.TextChanged += this.txtText_TextChanged;
+			this.txtTextPosition.ValueChanged += this.txtTextPosition_ValueChanged;
+			this.txtShiftText.TextChanged += this.txtShiftText_TextChanged;
+			this.lstKeyCodes.SelectedIndexChanged += this.lstKeyCodes_SelectedIndexChanged;
+			this.chkChangeOnCaps.CheckedChanged += this.chkChangeOnCaps_CheckedChanged;
+		}
 
-        #region Boundaries
+		#region Boundaries
 
-        /// <summary>
-        /// Handles selecting an item in the boundaries list.
-        /// </summary>
-        private void lstBoundaries_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (this.lstBoundaries.SelectedItem == null) return;
+		/// <summary>
+		/// Handles selecting an item in the boundaries list.
+		/// </summary>
+		private void lstBoundaries_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			if(this.lstBoundaries.SelectedItem == null) return;
 
-            this.txtBoundaries.X = ((TPoint) this.lstBoundaries.SelectedItem).X;
-            this.txtBoundaries.Y = ((TPoint) this.lstBoundaries.SelectedItem).Y;
-        }
+			this.txtBoundaries.X = ((TPoint)this.lstBoundaries.SelectedItem).X;
+			this.txtBoundaries.Y = ((TPoint)this.lstBoundaries.SelectedItem).Y;
+		}
 
-        /// <summary>
-        /// Handles adding a boundary, sets the new boundaries and invokes the changed event.
-        /// </summary>
-        private void btnAddBoundary_Click(object sender, EventArgs e)
-        {
-            var newBoundary = new TPoint(this.txtBoundaries.X, this.txtBoundaries.Y);
-            if (this.lstBoundaries.Items.Cast<TPoint>().Any(p => p.X == newBoundary.X && p.Y == newBoundary.Y)) return;
+		/// <summary>
+		/// Handles adding a boundary, sets the new boundaries and invokes the changed event.
+		/// </summary>
+		private void btnAddBoundary_Click(object sender, EventArgs e)
+		{
+			var newBoundary = new TPoint(this.txtBoundaries.X, this.txtBoundaries.Y);
+			if(this.lstBoundaries.Items.Cast<TPoint>().Any(p => p.X == newBoundary.X && p.Y == newBoundary.Y)) return;
 
-            var newIndex = Math.Max(0, this.lstBoundaries.SelectedIndex);
-            this.lstBoundaries.Items.Insert(newIndex, newBoundary);
-            this.lstBoundaries.SelectedIndex = newIndex;
+			var newIndex = Math.Max(0, this.lstBoundaries.SelectedIndex);
+			this.lstBoundaries.Items.Insert(newIndex, newBoundary);
+			this.lstBoundaries.SelectedIndex = newIndex;
 
-            this.currentDefinition =
-                this.currentDefinition.Modify(boundaries: this.lstBoundaries.Items.Cast<TPoint>().ToList());
-            this.DefinitionChanged?.Invoke(this.currentDefinition);
-        }
+			this.currentDefinition =
+				this.currentDefinition.Modify(boundaries: this.lstBoundaries.Items.Cast<TPoint>().ToList());
+			this.DefinitionChanged?.Invoke(this.currentDefinition);
+		}
 
-        /// <summary>
-        /// Handles updating a boundary, sets the new boundaries and invokes the changed event.
-        /// </summary>
-        private void btnUpdateBoundary_Click(object sender, EventArgs e)
-        {
-            if (this.lstBoundaries.SelectedItem == null) return;
+		/// <summary>
+		/// Handles updating a boundary, sets the new boundaries and invokes the changed event.
+		/// </summary>
+		private void btnUpdateBoundary_Click(object sender, EventArgs e)
+		{
+			if(this.lstBoundaries.SelectedItem == null) return;
 
-            var updateIndex = this.lstBoundaries.SelectedIndex;
-            var newBoundary = new TPoint(this.txtBoundaries.X, this.txtBoundaries.Y);
+			var updateIndex = this.lstBoundaries.SelectedIndex;
+			var newBoundary = new TPoint(this.txtBoundaries.X, this.txtBoundaries.Y);
 
-            if (this.lstBoundaries.Items.Cast<TPoint>().Any(p => p.X == newBoundary.X && p.Y == newBoundary.Y)) return;
+			if(this.lstBoundaries.Items.Cast<TPoint>().Any(p => p.X == newBoundary.X && p.Y == newBoundary.Y)) return;
 
-            this.lstBoundaries.Items.RemoveAt(updateIndex);
-            this.lstBoundaries.Items.Insert(updateIndex, newBoundary);
-            this.lstBoundaries.SelectedIndex = updateIndex;
+			this.lstBoundaries.Items.RemoveAt(updateIndex);
+			this.lstBoundaries.Items.Insert(updateIndex, newBoundary);
+			this.lstBoundaries.SelectedIndex = updateIndex;
 
-            this.currentDefinition =
-                this.currentDefinition.Modify(boundaries: this.lstBoundaries.Items.Cast<TPoint>().ToList());
-            this.DefinitionChanged?.Invoke(this.currentDefinition);
-        }
+			this.currentDefinition =
+				this.currentDefinition.Modify(boundaries: this.lstBoundaries.Items.Cast<TPoint>().ToList());
+			this.DefinitionChanged?.Invoke(this.currentDefinition);
+		}
 
-        /// <summary>
-        /// Handles removing a boundary, sets the new boundaries and invokes the changed event.
-        /// </summary>
-        private void btnRemoveBoundary_Click(object sender, EventArgs e)
-        {
-            if (this.lstBoundaries.SelectedItem == null) return;
-            if (this.lstBoundaries.Items.Count < 4) return;
+		/// <summary>
+		/// Handles removing a boundary, sets the new boundaries and invokes the changed event.
+		/// </summary>
+		private void btnRemoveBoundary_Click(object sender, EventArgs e)
+		{
+			if(this.lstBoundaries.SelectedItem == null) return;
+			if(this.lstBoundaries.Items.Count < 4) return;
 
-            var index = this.lstBoundaries.SelectedIndex;
-            this.lstBoundaries.Items.Remove(this.lstBoundaries.SelectedItem);
-            this.lstBoundaries.SelectedIndex = Math.Min(this.lstBoundaries.Items.Count - 1, index);
+			var index = this.lstBoundaries.SelectedIndex;
+			this.lstBoundaries.Items.Remove(this.lstBoundaries.SelectedItem);
+			this.lstBoundaries.SelectedIndex = Math.Min(this.lstBoundaries.Items.Count - 1, index);
 
-            this.currentDefinition =
-                this.currentDefinition.Modify(boundaries: this.lstBoundaries.Items.Cast<TPoint>().ToList());
-            this.DefinitionChanged?.Invoke(this.currentDefinition);
-        }
+			this.currentDefinition =
+				this.currentDefinition.Modify(boundaries: this.lstBoundaries.Items.Cast<TPoint>().ToList());
+			this.DefinitionChanged?.Invoke(this.currentDefinition);
+		}
 
-        /// <summary>
-        /// Handles moving a boundary up in the list, sets the new boundaries and invokes the changed event.
-        /// </summary>
-        private void btnBoundaryUp_Click(object sender, EventArgs e)
-        {
-            var item = this.lstBoundaries.SelectedItem;
-            var index = this.lstBoundaries.SelectedIndex;
+		/// <summary>
+		/// Handles moving a boundary up in the list, sets the new boundaries and invokes the changed event.
+		/// </summary>
+		private void btnBoundaryUp_Click(object sender, EventArgs e)
+		{
+			var item = this.lstBoundaries.SelectedItem;
+			var index = this.lstBoundaries.SelectedIndex;
 
-            if (item == null || index == 0) return;
+			if(item == null || index == 0) return;
 
-            this.lstBoundaries.Items.Remove(item);
-            this.lstBoundaries.Items.Insert(index - 1, item);
-            this.lstBoundaries.SelectedIndex = index - 1;
+			this.lstBoundaries.Items.Remove(item);
+			this.lstBoundaries.Items.Insert(index - 1, item);
+			this.lstBoundaries.SelectedIndex = index - 1;
 
-            this.currentDefinition =
-                this.currentDefinition.Modify(boundaries: this.lstBoundaries.Items.Cast<TPoint>().ToList());
-            this.DefinitionChanged?.Invoke(this.currentDefinition);
-        }
+			this.currentDefinition =
+				this.currentDefinition.Modify(boundaries: this.lstBoundaries.Items.Cast<TPoint>().ToList());
+			this.DefinitionChanged?.Invoke(this.currentDefinition);
+		}
 
-        /// <summary>
-        /// Handles moving a boundary down in the list, sets the new boundaries and invokes the changed event.
-        /// </summary>
-        private void btnBoundaryDown_Click(object sender, EventArgs e)
-        {
-            var item = this.lstBoundaries.SelectedItem;
-            var index = this.lstBoundaries.SelectedIndex;
+		/// <summary>
+		/// Handles moving a boundary down in the list, sets the new boundaries and invokes the changed event.
+		/// </summary>
+		private void btnBoundaryDown_Click(object sender, EventArgs e)
+		{
+			var item = this.lstBoundaries.SelectedItem;
+			var index = this.lstBoundaries.SelectedIndex;
 
-            if (item == null || index == this.lstBoundaries.Items.Count - 1) return;
+			if(item == null || index == this.lstBoundaries.Items.Count - 1) return;
 
-            this.lstBoundaries.Items.Remove(item);
-            this.lstBoundaries.Items.Insert(index + 1, item);
-            this.lstBoundaries.SelectedIndex = index + 1;
+			this.lstBoundaries.Items.Remove(item);
+			this.lstBoundaries.Items.Insert(index + 1, item);
+			this.lstBoundaries.SelectedIndex = index + 1;
 
-            this.currentDefinition =
-                this.currentDefinition.Modify(boundaries: this.lstBoundaries.Items.Cast<TPoint>().ToList());
-            this.DefinitionChanged?.Invoke(this.currentDefinition);
-        }
+			this.currentDefinition =
+				this.currentDefinition.Modify(boundaries: this.lstBoundaries.Items.Cast<TPoint>().ToList());
+			this.DefinitionChanged?.Invoke(this.currentDefinition);
+		}
 
-        /// <summary>
-        /// Handles the click event of the "Rectangle" button, opens the dialog.
-        /// </summary>
-        private void btnRectangle_Click(object sender, EventArgs e)
-        {
-            var rectangle = TRectangle.FromPointList(this.lstBoundaries.Items.Cast<TPoint>().ToArray());
-            using (var rectangleForm = new RectangleBoundaryForm(rectangle))
-            {
-                rectangleForm.DimensionsSet += OnRectangleDimensionsSet;
-                rectangleForm.ShowDialog(this);
-            }
-        }
+		/// <summary>
+		/// Handles the click event of the "Rectangle" button, opens the dialog.
+		/// </summary>
+		private void btnRectangle_Click(object sender, EventArgs e)
+		{
+			var rectangle = TRectangle.FromPointList(this.lstBoundaries.Items.Cast<TPoint>().ToArray());
+			using(var rectangleForm = new RectangleBoundaryForm(rectangle))
+			{
+				rectangleForm.DimensionsSet += OnRectangleDimensionsSet;
+				rectangleForm.ShowDialog(this);
+			}
+		}
 
-        /// <summary>
-        /// Called when the user clicks "Apply" in the rectangle dialog. Sets the new boundaries and invokes the changed event.
-        /// </summary>
-        private void OnRectangleDimensionsSet(TRectangle rectangle)
-        {
-            this.lstBoundaries.Items.Clear();
-            this.lstBoundaries.Items.Add(rectangle.TopLeft);
-            this.lstBoundaries.Items.Add(rectangle.TopRight);
-            this.lstBoundaries.Items.Add(rectangle.BottomRight);
-            this.lstBoundaries.Items.Add(rectangle.BottomLeft);
+		/// <summary>
+		/// Called when the user clicks "Apply" in the rectangle dialog. Sets the new boundaries and invokes the changed event.
+		/// </summary>
+		private void OnRectangleDimensionsSet(TRectangle rectangle)
+		{
+			this.lstBoundaries.Items.Clear();
+			this.lstBoundaries.Items.Add(rectangle.TopLeft);
+			this.lstBoundaries.Items.Add(rectangle.TopRight);
+			this.lstBoundaries.Items.Add(rectangle.BottomRight);
+			this.lstBoundaries.Items.Add(rectangle.BottomLeft);
 
-            this.currentDefinition =
-                this.currentDefinition.Modify(boundaries: this.lstBoundaries.Items.Cast<TPoint>().ToList());
-            this.DefinitionChanged?.Invoke(this.currentDefinition);
-        }
+			this.currentDefinition =
+				this.currentDefinition.Modify(boundaries: this.lstBoundaries.Items.Cast<TPoint>().ToList());
+			this.DefinitionChanged?.Invoke(this.currentDefinition);
+		}
 
-        #endregion Boundaries
+		#endregion Boundaries
 
-        #region KeyCodes
+		#region KeyCodes
 
-        /// <summary>
-        /// Handles selecting an item in the boundaries list.
-        /// </summary>
-        private void lstKeyCodes_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (this.lstKeyCodes.SelectedItem != null)
-                this.udKeyCode.Value = Convert.ToInt32(this.lstKeyCodes.SelectedItem);
-        }
+		/// <summary>
+		/// Handles selecting an item in the boundaries list.
+		/// </summary>
+		private void lstKeyCodes_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			if(this.lstKeyCodes.SelectedItem != null)
+				this.udKeyCode.Value = Convert.ToInt32(this.lstKeyCodes.SelectedItem);
+		}
 
-        /// <summary>
-        /// Handles adding a key code, sets the new key codes and invokes the changed event.
-        /// </summary>
-        private void btnAddKeyCode_Click(object sender, EventArgs e)
-        {
-            var newVal = Convert.ToInt32(this.udKeyCode.Value);
-            if (this.lstKeyCodes.Items.Contains(newVal)) return;
+		/// <summary>
+		/// Handles adding a key code, sets the new key codes and invokes the changed event.
+		/// </summary>
+		private void btnAddKeyCode_Click(object sender, EventArgs e)
+		{
+			var newVal = Convert.ToInt32(this.udKeyCode.Value);
+			if(this.lstKeyCodes.Items.Contains(newVal)) return;
 
-            this.lstKeyCodes.Items.Add(newVal);
-            this.lstKeyCodes.SelectedIndex = this.lstKeyCodes.Items.Count - 1;
+			this.lstKeyCodes.Items.Add(newVal);
+			this.lstKeyCodes.SelectedIndex = this.lstKeyCodes.Items.Count - 1;
 
-            this.currentDefinition =
-                this.currentDefinition.Modify(keyCodes: this.lstKeyCodes.Items.Cast<int>().ToList());
-            this.DefinitionChanged?.Invoke(this.currentDefinition);
-        }
+			this.currentDefinition =
+				this.currentDefinition.Modify(keyCodes: this.lstKeyCodes.Items.Cast<int>().ToList());
+			this.DefinitionChanged?.Invoke(this.currentDefinition);
+		}
 
-        /// <summary>
-        /// Handles removing a key code, sets the new key codes and invokes the changed event.
-        /// </summary>
-        private void btnRemoveKeyCode_Click(object sender, EventArgs e)
-        {
-            if (this.lstKeyCodes.SelectedItem == null) return;
+		/// <summary>
+		/// Handles removing a key code, sets the new key codes and invokes the changed event.
+		/// </summary>
+		private void btnRemoveKeyCode_Click(object sender, EventArgs e)
+		{
+			if(this.lstKeyCodes.SelectedItem == null) return;
 
-            var index = this.lstKeyCodes.SelectedIndex;
-            this.lstKeyCodes.Items.Remove(this.lstKeyCodes.SelectedItem);
+			var index = this.lstKeyCodes.SelectedIndex;
+			this.lstKeyCodes.Items.Remove(this.lstKeyCodes.SelectedItem);
 
-            this.lstKeyCodes.Items.Remove(this.lstKeyCodes.SelectedItem);
-            this.lstKeyCodes.SelectedIndex = Math.Min(this.lstKeyCodes.Items.Count - 1, index);
+			this.lstKeyCodes.Items.Remove(this.lstKeyCodes.SelectedItem);
+			this.lstKeyCodes.SelectedIndex = Math.Min(this.lstKeyCodes.Items.Count - 1, index);
 
-            this.currentDefinition =
-                this.currentDefinition.Modify(keyCodes: this.lstKeyCodes.Items.Cast<int>().ToList());
-            this.DefinitionChanged?.Invoke(this.currentDefinition);
-        }
+			this.currentDefinition =
+				this.currentDefinition.Modify(keyCodes: this.lstKeyCodes.Items.Cast<int>().ToList());
+			this.DefinitionChanged?.Invoke(this.currentDefinition);
+		}
 
-        /// <summary>
-        /// Toggles the key-code detection.
-        /// </summary>
-        private void btnDetectKeyCode_Click(object sender, EventArgs e)
-        {
-            this.detectingKeyCode = !this.detectingKeyCode;
+		/// <summary>
+		/// Toggles the key-code detection.
+		/// </summary>
+		private void btnDetectKeyCode_Click(object sender, EventArgs e)
+		{
+			this.detectingKeyCode = !this.detectingKeyCode;
 
-            if (this.detectingKeyCode)
-            {
-                this.btnDetectKeyCode.Text = "Detecting...";
-                Hooking.Interop.HookManager.KeyboardInsert = code =>
-                {
-                    this.udKeyCode.Value = code;
-                    return true;
-                };
-            }
-            else
-            {
-                this.btnDetectKeyCode.Text = "Detect";
-                Hooking.Interop.HookManager.KeyboardInsert = null;
-            }
-        }
+			if(this.detectingKeyCode)
+			{
+				this.btnDetectKeyCode.Text = "Detecting...";
+				Hooking.Interop.HookManager.KeyboardInsert = code =>
+				{
+					this.udKeyCode.Value = code;
+					return true;
+				};
+			}
+			else
+			{
+				this.btnDetectKeyCode.Text = "Detect";
+				Hooking.Interop.HookManager.KeyboardInsert = null;
+			}
+		}
 
-        /// <summary>
-        /// Disables key-code detection, in case it was still active.
-        /// </summary>
-        private void KeyboardKeyPropertiesForm_FormClosing(object sender, FormClosingEventArgs e)
-        {
-            this.btnDetectKeyCode.Text = "Detect";
-            Hooking.Interop.HookManager.KeyboardInsert = null;
-        }
+		/// <summary>
+		/// Disables key-code detection, in case it was still active.
+		/// </summary>
+		private void KeyboardKeyPropertiesForm_FormClosing(object sender, FormClosingEventArgs e)
+		{
+			this.btnDetectKeyCode.Text = "Detect";
+			Hooking.Interop.HookManager.KeyboardInsert = null;
+		}
 
-        #endregion KeyCodes
+		#endregion KeyCodes
 
-        /// <summary>
-        /// Handles changing the text, sets the new text and invokes the changed event.
-        /// </summary>
-        private void txtText_TextChanged(object sender, EventArgs e)
-        {
-            this.currentDefinition = this.currentDefinition.Modify(text: this.txtText.Text);
-            this.DefinitionChanged?.Invoke(this.currentDefinition);
-        }
+		/// <summary>
+		/// Handles changing the text, sets the new text and invokes the changed event.
+		/// </summary>
+		private void txtText_TextChanged(object sender, EventArgs e)
+		{
+			this.currentDefinition = this.currentDefinition.Modify(text: this.txtText.Text);
+			this.DefinitionChanged?.Invoke(this.currentDefinition);
+		}
 
-        /// <summary>
-        /// Handles changing the shift text, sets the new shift text and invokes the changed event.
-        /// </summary>
-        private void txtShiftText_TextChanged(object sender, EventArgs e)
-        {
-            this.currentDefinition = this.currentDefinition.Modify(shiftText: this.txtShiftText.Text);
-            this.DefinitionChanged?.Invoke(this.currentDefinition);
-        }
+		/// <summary>
+		/// Handles changing the shift text, sets the new shift text and invokes the changed event.
+		/// </summary>
+		private void txtShiftText_TextChanged(object sender, EventArgs e)
+		{
+			this.currentDefinition = this.currentDefinition.Modify(shiftText: this.txtShiftText.Text);
+			this.DefinitionChanged?.Invoke(this.currentDefinition);
+		}
 
-        /// <summary>
-        /// Handles changing the text position, sets the new text position and invokes the changed event.
-        /// </summary>
-        private void txtTextPosition_ValueChanged(Controls.VectorTextBox sender, TPoint newValue)
-        {
-            this.UpdateTextPosition();
-        }
+		/// <summary>
+		/// Handles changing the text position, sets the new text position and invokes the changed event.
+		/// </summary>
+		private void txtTextPosition_ValueChanged(Controls.VectorTextBox sender, TPoint newValue)
+		{
+			this.UpdateTextPosition();
+		}
 
-        /// <summary>
-        /// Handles clicking of the "Center" button for the text location. Sets the input's value to the center of the button and updates the text.
-        /// </summary>
-        private void btnCenterText_Click(object sender, EventArgs e)
-        {
-            var bBox = this.currentDefinition.GetBoundingBox();
-            var center = new TPoint((bBox.Left + bBox.Right) / 2, (bBox.Top + bBox.Bottom) / 2);
+		/// <summary>
+		/// Handles clicking of the "Center" button for the text location. Sets the input's value to the center of the button and updates the text.
+		/// </summary>
+		private void btnCenterText_Click(object sender, EventArgs e)
+		{
+			var bBox = this.currentDefinition.GetBoundingBox();
+			var center = new TPoint((bBox.Left + bBox.Right) / 2, (bBox.Top + bBox.Bottom) / 2);
 
-            this.txtTextPosition.X = center.X;
-            this.txtTextPosition.Y = center.Y;
+			this.txtTextPosition.X = center.X;
+			this.txtTextPosition.Y = center.Y;
 
-            this.UpdateTextPosition();
-        }
+			this.UpdateTextPosition();
+		}
 
-        /// <summary>
-        /// Takes the current text position input value, updates the current defifinition with it and invokes the change events.
-        /// </summary>
-        private void UpdateTextPosition()
-        {
-            var newPos = new TPoint(this.txtTextPosition.X, this.txtTextPosition.Y);
+		/// <summary>
+		/// Takes the current text position input value, updates the current defifinition with it and invokes the change events.
+		/// </summary>
+		private void UpdateTextPosition()
+		{
+			var newPos = new TPoint(this.txtTextPosition.X, this.txtTextPosition.Y);
 
-            this.currentDefinition = this.currentDefinition.Modify(textPosition: newPos);
-            this.DefinitionChanged?.Invoke(this.currentDefinition);
-        }
+			this.currentDefinition = this.currentDefinition.Modify(textPosition: newPos);
+			this.DefinitionChanged?.Invoke(this.currentDefinition);
+		}
 
-        /// <summary>
-        /// Handles changing the change on caps state, sets the new value and invokes the changed event.
-        /// </summary>
-        private void chkChangeOnCaps_CheckedChanged(object sender, EventArgs e)
-        {
-            this.currentDefinition = this.currentDefinition.Modify(changeOnCaps: this.chkChangeOnCaps.Checked);
-            this.DefinitionChanged?.Invoke(this.currentDefinition);
-        }
+		/// <summary>
+		/// Handles changing the change on caps state, sets the new value and invokes the changed event.
+		/// </summary>
+		private void chkChangeOnCaps_CheckedChanged(object sender, EventArgs e)
+		{
+			this.currentDefinition = this.currentDefinition.Modify(changeOnCaps: this.chkChangeOnCaps.Checked);
+			this.DefinitionChanged?.Invoke(this.currentDefinition);
+		}
 
-        /// <summary>
-        /// Accepts the current definition.
-        /// </summary>
-        private void AcceptButton2_Click(object sender, EventArgs e)
-        {
-            this.DefinitionSaved?.Invoke();
-            this.DialogResult = DialogResult.OK;
-        }
+		/// <summary>
+		/// Accepts the current definition.
+		/// </summary>
+		private void AcceptButton2_Click(object sender, EventArgs e)
+		{
+			this.DefinitionSaved?.Invoke();
+			this.DialogResult = DialogResult.OK;
+		}
 
-        /// <summary>
-        /// Cancels the current definition, reverting to the initial definition.
-        /// </summary>
-        private void CancelButton2_Click(object sender, EventArgs e)
-        {
-            this.DefinitionChanged?.Invoke(this.initialDefinition);
-            this.DialogResult = DialogResult.Cancel;
-        }
-    }
+		/// <summary>
+		/// Cancels the current definition, reverting to the initial definition.
+		/// </summary>
+		private void CancelButton2_Click(object sender, EventArgs e)
+		{
+			this.DefinitionChanged?.Invoke(this.initialDefinition);
+			this.DialogResult = DialogResult.Cancel;
+		}
+
+
+		/// <summary>
+		/// Toggles whether the current KeyboardKeyDefinition should function in OR mode (checked) or AND mode (unchecked)
+		/// </summary>
+		private void keyCodesOrModeCheckbox_CheckedChanged(object sender, EventArgs e)
+		{
+			this.currentDefinition = this.currentDefinition.Modify(keyCodeOrMode: this.keyCodesOrModeCheckbox.Checked);
+			this.DefinitionChanged?.Invoke(this.currentDefinition);
+		}
+	}
 }

--- a/NohBoard/NohBoard/Keyboard/ElementDefinitions/KeyboardKeyDefinition.cs
+++ b/NohBoard/NohBoard/Keyboard/ElementDefinitions/KeyboardKeyDefinition.cs
@@ -47,53 +47,53 @@ namespace ThoNohT.NohBoard.Keyboard.ElementDefinitions
         [DataMember]
         public bool ChangeOnCaps { get; private set; }
 
-		/// <summary>
-		/// Indicates if all keys codes must be pressed (false) to be pressed or if any (true) can be pressed
-		/// </summary>
-		[DataMember]
-		public bool KeyCodesOrMode { get; private set; }
+	/// <summary>
+	/// Indicates if all keys codes must be pressed (false) to be pressed or if any (true) can be pressed
+	/// </summary>
+	[DataMember]
+	public bool KeyCodesOrMode { get; private set; }
 
 
-		#endregion Properties
+	#endregion Properties
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="KeyboardKeyDefinition" /> class.
-		/// </summary>
-		/// <param name="id">The identifier of the key.</param>
-		/// <param name="boundaries">The boundaries.</param>
-		/// <param name="keyCodes">The keycodes.</param>
-		/// <param name="normalText">The normal text.</param>
-		/// <param name="shiftText">The shift text.</param>
-		/// <param name="changeOnCaps">Whether to change to shift text on caps lock.</param>
-		/// <param name="textPosition">The new text position.
-		/// If not provided, the new position will be recalculated from the bounding box of the key.</param>
-		/// <param name="manipulation">The current manipulation.</param>
+	/// <summary>
+	/// Initializes a new instance of the <see cref="KeyboardKeyDefinition" /> class.
+	/// </summary>
+	/// <param name="id">The identifier of the key.</param>
+	/// <param name="boundaries">The boundaries.</param>
+	/// <param name="keyCodes">The keycodes.</param>
+	/// <param name="normalText">The normal text.</param>
+	/// <param name="shiftText">The shift text.</param>
+	/// <param name="changeOnCaps">Whether to change to shift text on caps lock.</param>
+	/// <param name="textPosition">The new text position.
+	/// If not provided, the new position will be recalculated from the bounding box of the key.</param>
+	/// <param name="manipulation">The current manipulation.</param>
         /// <param name="keyCodesOrMode">The key definition should allow any key code to trigger it</param>
-		public KeyboardKeyDefinition(
-			int id,
-			List<TPoint> boundaries,
-			List<int> keyCodes,
-			string normalText,
-			string shiftText,
-			bool changeOnCaps,
-			TPoint textPosition = null,
-			ElementManipulation manipulation = null,
-			bool keyCodesOrMode = true) : base(id, boundaries, keyCodes, normalText, textPosition, manipulation)
-		{
-			this.ShiftText = shiftText;
-			this.ChangeOnCaps = changeOnCaps;
-			this.KeyCodesOrMode = keyCodesOrMode;
-		}
+	public KeyboardKeyDefinition(
+		int id,
+		List<TPoint> boundaries,
+		List<int> keyCodes,
+		string normalText,
+		string shiftText,
+		bool changeOnCaps,
+		TPoint textPosition = null,
+		ElementManipulation manipulation = null,
+		bool keyCodesOrMode = true) : base(id, boundaries, keyCodes, normalText, textPosition, manipulation)
+	{
+		this.ShiftText = shiftText;
+		this.ChangeOnCaps = changeOnCaps;
+		this.KeyCodesOrMode = keyCodesOrMode;
+	}
 
 
-		/// <summary>
-		/// Renders the key in the specified surface.
-		/// </summary>
-		/// <param name="g">The GDI+ surface to render on.</param>
-		/// <param name="pressed">A value indicating whether to render the key in its pressed state or not.</param>
-		/// <param name="shift">A value indicating whether shift is pressed during the render.</param>
-		/// <param name="capsLock">A value indicating whether caps lock is pressed during the render.</param>
-		public void Render(Graphics g, bool pressed, bool shift, bool capsLock)
+	/// <summary>
+	/// Renders the key in the specified surface.
+	/// </summary>
+	/// <param name="g">The GDI+ surface to render on.</param>
+	/// <param name="pressed">A value indicating whether to render the key in its pressed state or not.</param>
+	/// <param name="shift">A value indicating whether shift is pressed during the render.</param>
+	/// <param name="capsLock">A value indicating whether caps lock is pressed during the render.</param>
+	public void Render(Graphics g, bool pressed, bool shift, bool capsLock)
         {
             var style = GlobalSettings.CurrentStyle.TryGetElementStyle<KeyStyle>(this.Id)
                             ?? GlobalSettings.CurrentStyle.DefaultKeyStyle;

--- a/NohBoard/NohBoard/Keyboard/ElementDefinitions/KeyboardKeyDefinition.cs
+++ b/NohBoard/NohBoard/Keyboard/ElementDefinitions/KeyboardKeyDefinition.cs
@@ -47,43 +47,53 @@ namespace ThoNohT.NohBoard.Keyboard.ElementDefinitions
         [DataMember]
         public bool ChangeOnCaps { get; private set; }
 
-        #endregion Properties
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="KeyboardKeyDefinition" /> class.
-        /// </summary>
-        /// <param name="id">The identifier of the key.</param>
-        /// <param name="boundaries">The boundaries.</param>
-        /// <param name="keyCodes">The keycodes.</param>
-        /// <param name="normalText">The normal text.</param>
-        /// <param name="shiftText">The shift text.</param>
-        /// <param name="changeOnCaps">Whether to change to shift text on caps lock.</param>
-        /// <param name="textPosition">The new text position.
-        /// If not provided, the new position will be recalculated from the bounding box of the key.</param>
-        /// <param name="manipulation">The current manipulation.</param>
-        public KeyboardKeyDefinition(
-            int id,
-            List<TPoint> boundaries,
-            List<int> keyCodes,
-            string normalText,
-            string shiftText,
-            bool changeOnCaps,
-            TPoint textPosition = null,
-            ElementManipulation manipulation = null) : base(id, boundaries, keyCodes, normalText, textPosition, manipulation)
-        {
-            this.ShiftText = shiftText;
-            this.ChangeOnCaps = changeOnCaps;
-        }
+		/// <summary>
+		/// Indicates if all keys codes must be pressed (false) to be pressed or if any (true) can be pressed
+		/// </summary>
+		[DataMember]
+		public bool KeyCodesOrMode { get; private set; }
 
 
-        /// <summary>
-        /// Renders the key in the specified surface.
-        /// </summary>
-        /// <param name="g">The GDI+ surface to render on.</param>
-        /// <param name="pressed">A value indicating whether to render the key in its pressed state or not.</param>
-        /// <param name="shift">A value indicating whether shift is pressed during the render.</param>
-        /// <param name="capsLock">A value indicating whether caps lock is pressed during the render.</param>
-        public void Render(Graphics g, bool pressed, bool shift, bool capsLock)
+		#endregion Properties
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="KeyboardKeyDefinition" /> class.
+		/// </summary>
+		/// <param name="id">The identifier of the key.</param>
+		/// <param name="boundaries">The boundaries.</param>
+		/// <param name="keyCodes">The keycodes.</param>
+		/// <param name="normalText">The normal text.</param>
+		/// <param name="shiftText">The shift text.</param>
+		/// <param name="changeOnCaps">Whether to change to shift text on caps lock.</param>
+		/// <param name="textPosition">The new text position.
+		/// If not provided, the new position will be recalculated from the bounding box of the key.</param>
+		/// <param name="manipulation">The current manipulation.</param>
+        /// <param name="keyCodesOrMode">The key definition should allow any key code to trigger it</param>
+		public KeyboardKeyDefinition(
+			int id,
+			List<TPoint> boundaries,
+			List<int> keyCodes,
+			string normalText,
+			string shiftText,
+			bool changeOnCaps,
+			TPoint textPosition = null,
+			ElementManipulation manipulation = null,
+			bool keyCodesOrMode = true) : base(id, boundaries, keyCodes, normalText, textPosition, manipulation)
+		{
+			this.ShiftText = shiftText;
+			this.ChangeOnCaps = changeOnCaps;
+			this.KeyCodesOrMode = keyCodesOrMode;
+		}
+
+
+		/// <summary>
+		/// Renders the key in the specified surface.
+		/// </summary>
+		/// <param name="g">The GDI+ surface to render on.</param>
+		/// <param name="pressed">A value indicating whether to render the key in its pressed state or not.</param>
+		/// <param name="shift">A value indicating whether shift is pressed during the render.</param>
+		/// <param name="capsLock">A value indicating whether caps lock is pressed during the render.</param>
+		public void Render(Graphics g, bool pressed, bool shift, bool capsLock)
         {
             var style = GlobalSettings.CurrentStyle.TryGetElementStyle<KeyStyle>(this.Id)
                             ?? GlobalSettings.CurrentStyle.DefaultKeyStyle;
@@ -320,43 +330,45 @@ namespace ThoNohT.NohBoard.Keyboard.ElementDefinitions
             throw new Exception("Cannot modify  the mouse properties of a keyboard key.");
         }
 
-        /// <summary>
-        /// Returns a new version of this element definition with the specified properties changed.
-        /// </summary>
-        /// <param name="boundaries">The new boundaries, or <c>null</c> if not changed.</param>
-        /// <param name="keyCodes">The new key codes, or <c>null</c> if not changed.</param>
-        /// <param name="text">The new text, or <c>null</c> if not changed.</param>
-        /// <param name="shiftText">The new shift text, or <c>null</c> if not changed.</param>
-        /// <param name="changeOnCaps">The new change on caps, or <c>null</c> if not changed.</param>
-        /// <param name="textPosition">The new text position, or <c>null</c> if not changed.</param>
-        /// <returns>The new element definition.</returns>
-        public KeyboardKeyDefinition Modify(
-            List<TPoint> boundaries = null, List<int> keyCodes = null, string text = null, string shiftText = null,
-            bool? changeOnCaps = null, TPoint textPosition = null)
-        {
-            return new KeyboardKeyDefinition(
-                this.Id,
-                boundaries ?? this.Boundaries.Select(x => x.Clone()).ToList(),
-                keyCodes ?? this.KeyCodes.ToList(),
-                text ?? this.Text,
-                shiftText ?? this.ShiftText,
-                changeOnCaps ?? this.ChangeOnCaps,
-                textPosition ?? this.TextPosition,
-                this.CurrentManipulation);
-        }
+		/// <summary>
+		/// Returns a new version of this element definition with the specified properties changed.
+		/// </summary>
+		/// <param name="boundaries">The new boundaries, or <c>null</c> if not changed.</param>
+		/// <param name="keyCodes">The new key codes, or <c>null</c> if not changed.</param>
+		/// <param name="text">The new text, or <c>null</c> if not changed.</param>
+		/// <param name="shiftText">The new shift text, or <c>null</c> if not changed.</param>
+		/// <param name="changeOnCaps">The new change on caps, or <c>null</c> if not changed.</param>
+		/// <param name="textPosition">The new text position, or <c>null</c> if not changed.</param>
+		/// <param name="keyCodesOrMode">The key definition should allow any key code to trigger it</param>
+		/// <returns>The new element definition.</returns>
+		public KeyboardKeyDefinition Modify(
+			List<TPoint> boundaries = null, List<int> keyCodes = null, string text = null, string shiftText = null,
+			bool? changeOnCaps = null, TPoint textPosition = null, bool? keyCodeOrMode = null)
+		{
+			return new KeyboardKeyDefinition(
+				this.Id,
+				boundaries ?? this.Boundaries.Select(x => x.Clone()).ToList(),
+				keyCodes ?? this.KeyCodes.ToList(),
+				text ?? this.Text,
+				shiftText ?? this.ShiftText,
+				changeOnCaps ?? this.ChangeOnCaps,
+				textPosition ?? this.TextPosition,
+				this.CurrentManipulation,
+				keyCodeOrMode ?? this.KeyCodesOrMode);
+		}
 
-        #endregion Transformations
+		#endregion Transformations
 
-        #region Private methods
+		#region Private methods
 
-        /// <summary>
-        /// Determines whether to use the shift text or the regular text for this key depening on the shift, caps lock
-        /// state and the key's properties. Returns the text that should be displayed for this state.
-        /// </summary>
-        /// <param name="shift">Whether shift is pressed.</param>
-        /// <param name="capsLock">Whether caps lock is active.</param>
-        /// <returns>The text to display for this key.</returns>
-        private string GetText(bool shift, bool capsLock)
+		/// <summary>
+		/// Determines whether to use the shift text or the regular text for this key depening on the shift, caps lock
+		/// state and the key's properties. Returns the text that should be displayed for this state.
+		/// </summary>
+		/// <param name="shift">Whether shift is pressed.</param>
+		/// <param name="capsLock">Whether caps lock is active.</param>
+		/// <returns>The text to display for this key.</returns>
+		private string GetText(bool shift, bool capsLock)
         {
             if (GlobalSettings.Settings.Capitalization != CapitalizationMethod.FollowKeys)
             {


### PR DESCRIPTION
This PR adds the ability for KeyboardKeyDefinitions to register as being pressed if any of their key codes are pressed (rather than requiring all of them). 


In your review I ask for special attention to the last part of the Keyboard Key Pressed logic but I couldn't quite parse what the point of it was. I removed this whole part:

```
if(kkDef.KeyCodes.Count == 1
	&& allDefs.OfType<KeyboardKeyDefinition>()
		.Any(d => d.KeyCodes.Count > 1
		&& d.KeyCodes.All(kbKeys.Contains)
		&& d.KeyCodes.ContainsAll(kkDef.KeyCodes))) pressed = false;
```
		
From what I can understand of it it says it's NOT pressed if there is any keyboard that exactly contains all the same keycodes and those keycodes are pressed? As in it's not allowing multiple to be triggered at the same time? 
I don't know why you would want to explicitly disallow that. 

I found that in this commit it didn't have that
https://github.com/ThoNohT/NohBoard/blob/4e2965a1bbecf6b2f342aa8f5e71ee5f819549b7/NohBoard/Forms/MainForm.cs
but in this commit it did 
https://github.com/ThoNohT/NohBoard/commit/8e20028a717fcba484aa2525e93bba3125ce9588#diff-ddd56594eed44ee72f2d8791249520ccd6802f26bd2a5e7767331930d6598a71
but the commit message implies it was only for edit mode? So I have no idea what the point of it was. 